### PR TITLE
build: fix script operating system compatibility issue

### DIFF
--- a/packages/wujie-core/package.json
+++ b/packages/wujie-core/package.json
@@ -11,9 +11,9 @@
   ],
   "scripts": {
     "lib": "webpack build --config webpack.config.js",
-    "esm": "BABEL_ENV=esm babel ./src --out-dir ./esm --extensions .ts --source-maps",
+    "esm": "cross-env BABEL_ENV=esm babel ./src --out-dir ./esm --extensions .ts --source-maps",
     "prepack": "bash build.sh",
-    "start": "BABEL_ENV=esm babel ./src --out-dir ./esm --extensions .ts --source-maps inline --watch",
+    "start": "cross-env BABEL_ENV=esm babel ./src --out-dir ./esm --extensions .ts --source-maps inline --watch",
     "lint": "eslint --ext .ts ./src  --fix && git add .",
     "test": "npm run test:unit && npm run test:integration",
     "test:unit": "jest -c __test__/unit/jest.config.js",

--- a/packages/wujie-react/package.json
+++ b/packages/wujie-react/package.json
@@ -11,9 +11,9 @@
   ],
   "scripts": {
     "lib": "webpack build --config webpack.config.js",
-    "esm": "BABEL_ENV=esm babel index.js --out-dir ./esm --source-maps",
+    "esm": "cross-env BABEL_ENV=esm babel index.js --out-dir ./esm --source-maps",
     "prepack": "bash build.sh",
-    "start": "BABEL_ENV=esm babel index.js --out-dir ./esm --source-maps inline --watch",
+    "start": "cross-env BABEL_ENV=esm babel index.js --out-dir ./esm --source-maps inline --watch",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "publishConfig": {
@@ -38,6 +38,7 @@
     "@babel/preset-env": "^7.16.0",
     "@babel/preset-react": "^7.16.7",
     "babel-loader": "^8.2.3",
+    "cross-env": "^7.0.3",
     "eslint": "^8.2.0",
     "eslint-plugin-react": "^7.29.3",
     "webpack": "^5.61.0",

--- a/packages/wujie-vue2/package.json
+++ b/packages/wujie-vue2/package.json
@@ -11,9 +11,9 @@
   ],
   "scripts": {
     "lib": "webpack build --mode=production --config webpack.config.js",
-    "esm": "BABEL_ENV=esm babel index.js --out-dir ./esm --source-maps",
+    "esm": "cross-env BABEL_ENV=esm babel index.js --out-dir ./esm --source-maps",
     "prepack": "bash build.sh",
-    "start": "BABEL_ENV=esm babel index.js --out-dir ./esm --source-maps inline --watch",
+    "start": "cross-env BABEL_ENV=esm babel index.js --out-dir ./esm --source-maps inline --watch",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "yiludege",
@@ -36,6 +36,7 @@
     "@babel/core": "^7.16.0",
     "@babel/preset-env": "^7.16.0",
     "babel-loader": "^8.2.3",
+    "cross-env": "^7.0.3",
     "eslint": "^8.2.0",
     "eslint-plugin-vue": "^8.0.3",
     "webpack": "^5.61.0",

--- a/packages/wujie-vue3/package.json
+++ b/packages/wujie-vue3/package.json
@@ -11,9 +11,9 @@
   ],
   "scripts": {
     "lib": "webpack build --mode=production --config webpack.config.js",
-    "esm": "BABEL_ENV=esm babel index.js --out-dir ./esm --source-maps",
+    "esm": "cross-env BABEL_ENV=esm babel index.js --out-dir ./esm --source-maps",
     "prepack": "bash build.sh",
-    "start": "BABEL_ENV=esm babel index.js --out-dir ./esm --source-maps inline --watch",
+    "start": "cross-env BABEL_ENV=esm babel index.js --out-dir ./esm --source-maps inline --watch",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "yiludege",
@@ -36,6 +36,7 @@
     "@babel/core": "^7.16.0",
     "@babel/preset-env": "^7.16.0",
     "babel-loader": "^8.2.3",
+    "cross-env": "^7.0.3",
     "eslint": "^8.2.0",
     "eslint-plugin-vue": "^8.0.3",
     "webpack": "^5.61.0",


### PR DESCRIPTION
Add cross-env package to fix start script operating system compatibility issue #8

**Windows验证结果：**
运行`npm run start`，正常启动，结果如下图所示
- 运行start脚本截图
![image](https://user-images.githubusercontent.com/53943926/178315880-5746c2d3-b8bf-42c9-9c68-49cfa186472e.png)

- 访问页面截图
![image](https://user-images.githubusercontent.com/53943926/178315412-3fa2a5ed-f3bd-4508-a616-ea1d10ff79db.png)
