### PR TITLE
feat: jsExcludes 和 cssExcludes 支持正则

### DIFF
--- a/packages/wujie-core/__test__/unit/utils.test.ts
+++ b/packages/wujie-core/__test__/unit/utils.test.ts
@@ -1,0 +1,42 @@
+
+import { getExcludes, isExcludeUrl } from "../../src/utils";
+
+describe('utils test', () => {
+  describe('getExcludes', () => {
+    test('plugins is undefined, should return empty array', () => {
+      expect(getExcludes('jsExcludes')).toEqual([]);
+      expect(getExcludes('cssExcludes')).toEqual([]);
+    })
+
+    test('sourceType is "jsExcludes", should return jsExcludes', () => {
+      const jsExcludes = ['https://www.foo/a.js', /b\.js/];
+      const plugins = [
+        {
+          jsExcludes,
+        }
+      ]
+      expect(getExcludes('jsExcludes', plugins)).toEqual(jsExcludes);
+    });
+
+    test('sourceType is "cssExcludes", should return cssExcludes', () => {
+      const cssExcludes = ['https://www.foo/a.css', /b\.css/];
+      const plugins = [
+        {
+          cssExcludes,
+        }
+      ]
+      expect(getExcludes('cssExcludes', plugins)).toEqual(cssExcludes);
+    });
+  });
+  describe('isExcludeUrl', () => {
+    test('url is not exclude, should return false', () => {
+      expect(isExcludeUrl('https://www.foo/a.js', ['https://www.foo/b.js'])).toBe(false);
+    });
+    test('url is exclude, should return true', () => {
+      expect(isExcludeUrl('https://www.foo/a.js', ['https://www.foo/a.js'])).toBe(true);
+    });
+    test('url is match regexp, should return true', () => {
+      expect(isExcludeUrl('https://www.foo/a.js', [/a\.js/])).toBe(true);
+    })
+   });
+})

--- a/packages/wujie-core/src/effect.ts
+++ b/packages/wujie-core/src/effect.ts
@@ -6,7 +6,17 @@ import {
   rawBodyInsertBefore,
   rawDocumentQuerySelector,
 } from "./common";
-import { isFunction, isHijackingTag, requestIdleCallback, compose, error, warn, nextTick } from "./utils";
+import {
+  isFunction,
+  isHijackingTag,
+  requestIdleCallback,
+  compose,
+  error,
+  warn,
+  nextTick,
+  isExcludeUrl,
+  getExcludes,
+} from "./utils";
 import { insertScriptToIframe } from "./iframe";
 import Wujie from "./sandbox";
 import { getHostCssRules } from "./shadow";
@@ -183,14 +193,7 @@ function rewriteAppendOrInsertChild(opts: {
         case "SCRIPT": {
           const { src, text, type, crossOrigin } = element as HTMLScriptElement;
           // 排除js
-          if (
-            src &&
-            !plugins
-              .map((plugin) => plugin.jsExcludes)
-              .reduce((pre, next) => pre.concat(next), [])
-              .filter((item) => item)
-              .includes(src)
-          ) {
+          if (!isExcludeUrl(src, getExcludes("jsExcludes", plugins))) {
             const execScript = (scriptResult) => {
               // 假如子应用被连续渲染两次，两次渲染会导致处理流程的交叉污染
               if (sandbox.iframe === null) return warn(WUJIE_TIPS_REPEAT_RENDER);

--- a/packages/wujie-core/src/entry.ts
+++ b/packages/wujie-core/src/entry.ts
@@ -5,7 +5,7 @@ import processTpl, {
   ScriptBaseObject,
   StyleObject,
 } from "./template";
-import { defaultGetPublicPath, getInlineCode, requestIdleCallback, error, compose } from "./utils";
+import { defaultGetPublicPath, getInlineCode, requestIdleCallback, error, compose, getExcludes } from "./utils";
 import { WUJIE_TIPS_NO_FETCH, WUJIE_TIPS_SCRIPT_ERROR_REQUESTED, WUJIE_TIPS_CSS_ERROR_REQUESTED } from "./constant";
 import Wujie from "./sandbox";
 import { plugin, loadErrorHandler } from "./index";
@@ -181,18 +181,8 @@ export default function importHTML(url: string, opts?: ImportEntryOpts): Promise
   const fetch = opts.fetch ?? defaultFetch;
   const { plugins, loadError } = opts;
   const htmlLoader = plugins ? compose(plugins.map((plugin) => plugin.htmlLoader)) : defaultGetTemplate;
-  const jsExcludes = plugins
-    ? plugins
-        .map((plugin) => plugin.jsExcludes)
-        .reduce((pre, next) => pre.concat(next), [])
-        .filter((item) => item)
-    : [];
-  const cssExcludes = plugins
-    ? plugins
-        .map((plugin) => plugin.cssExcludes)
-        .reduce((pre, next) => pre.concat(next), [])
-        .filter((item) => item)
-    : [];
+  const jsExcludes = getExcludes("jsExcludes", plugins);
+  const cssExcludes = getExcludes("cssExcludes", plugins);
   const getPublicPath = defaultGetPublicPath;
 
   const getHtmlParseResult = (url, htmlLoader) =>

--- a/packages/wujie-core/src/index.ts
+++ b/packages/wujie-core/src/index.ts
@@ -28,7 +28,7 @@ export interface plugin {
   /** 处理html的loader */
   htmlLoader?: (code: string) => string;
   /** js排除列表 */
-  jsExcludes?: Array<string>;
+  jsExcludes?: Array<string | RegExp>;
   /** 处理js加载前的loader */
   jsBeforeLoaders?: Array<ScriptObjectLoader>;
   /** 处理js的loader */
@@ -36,7 +36,7 @@ export interface plugin {
   /** 处理js加载后的loader */
   jsAfterLoaders?: Array<ScriptObjectLoader>;
   /** css排除列表 */
-  cssExcludes?: Array<string>;
+  cssExcludes?: Array<string | RegExp>;
   /** 处理css加载前的loader */
   cssBeforeLoaders?: Array<StyleObject>;
   /** 处理css的loader */

--- a/packages/wujie-core/src/utils.ts
+++ b/packages/wujie-core/src/utils.ts
@@ -244,3 +244,22 @@ export function execHooks(plugins: Array<plugin>, hookName: string, ...args: Arr
     error(e);
   }
 }
+
+// 获取插件 JS 或 CSS excludes
+export function getExcludes(
+  sourceType: "jsExcludes" | "cssExcludes",
+  plugins?: plugin[]
+): plugin["jsExcludes"] | plugin["cssExcludes"] {
+  const excludes = plugins
+    ? plugins
+        .map((plugin) => plugin[sourceType])
+        .reduce((pre, next) => pre.concat(next), [])
+        .filter((item) => item)
+    : [];
+  return excludes;
+}
+
+// 判断 url 是否被排查
+export function isExcludeUrl(url: string, excludes: plugin["jsExcludes"] | plugin["cssExcludes"]): boolean {
+  return excludes.some((excludeUrl) => (typeof excludeUrl === "string" ? url === excludeUrl : excludeUrl.test(url)));
+}

--- a/packages/wujie-doc/docs/guide/plugin.md
+++ b/packages/wujie-doc/docs/guide/plugin.md
@@ -28,8 +28,8 @@ const plugins = [
 
 ```javascript
 const plugins = [
-  // 子应用的 http://xxxxx.js 脚本将不在子应用中进行
-  { jsExcludes: ["http://xxxxx.js"] },
+  // 子应用的 http://xxxxx.js 或者符合正则 /test\.js/ 脚本将不在子应用中进行
+  { jsExcludes: ["http://xxxxx.js", /test\.js/] },
 ];
 ```
 


### PR DESCRIPTION

相关 isssue：https://github.com/Tencent/wujie/issues/20
目标：支持更加灵活的 jsExcludes 和 cssExcludes

- [x] 代码功能
- [x] 文档 
- [x] 测试用例

大佬先看以下改动的时候可以，如果可以，我再补充以下测试用例
