### PR TITLE
fix: 修复子应用字体无法加载的问题 

### DIFF
--- a/examples/main-react/package.json
+++ b/examples/main-react/package.json
@@ -62,6 +62,7 @@
   },
   "scripts": {
     "start": "node scripts/start.js",
+    "integration": "node scripts/integration.js",
     "build": "node scripts/build.js",
     "test": "node scripts/test.js"
   },

--- a/examples/main-react/scripts/integration.js
+++ b/examples/main-react/scripts/integration.js
@@ -128,7 +128,6 @@ checkBrowsers(paths.appPath, isInteractive)
       }
 
       console.log(chalk.cyan('Starting the development server...\n'));
-      openBrowser(urls.localUrlForBrowser);
     });
 
     ['SIGINT', 'SIGTERM'].forEach(function (sig) {

--- a/examples/main-vue/vue.config.js
+++ b/examples/main-vue/vue.config.js
@@ -9,7 +9,7 @@ module.exports = {
     headers: {
       "Access-Control-Allow-Origin": "*",
     },
-    open: true,
+    open: process.env.NODE_ENV === "development",
     port: "8000",
   },
 };

--- a/examples/react16/package.json
+++ b/examples/react16/package.json
@@ -52,6 +52,7 @@
     "source-map-loader": "^3.0.0",
     "style-loader": "^3.3.1",
     "tailwindcss": "^3.0.2",
+    "tdesign-icons-react": "^0.1.5",
     "terser-webpack-plugin": "^5.2.5",
     "web-vitals": "^2.1.4",
     "webpack": "^5.64.4",

--- a/examples/react16/src/App.js
+++ b/examples/react16/src/App.js
@@ -3,7 +3,8 @@ import { NavLink, Route, Switch, Redirect } from "react-router-dom";
 import Dialog from "./Dialog";
 import Location from "./Location";
 import Communication from "./Communication";
-import React17  from "./nest";
+import React17 from "./nest";
+import Font from "./Font";
 import logo from "./logo.svg";
 import Tag from "antd/es/tag";
 import Button from "antd/es/button";
@@ -42,7 +43,7 @@ export default function App() {
       <nav>
         <NavLink to="/home">首页</NavLink> | <NavLink to="/dialog">弹窗</NavLink> |{" "}
         <NavLink to="/location">路由</NavLink> | <NavLink to="/communication">通信</NavLink> |{" "}
-        <NavLink to="/nest">内嵌</NavLink>
+        <NavLink to="/nest">内嵌</NavLink> | <NavLink to="/font">字体</NavLink>
       </nav>
 
       <div>
@@ -64,6 +65,9 @@ export default function App() {
         </Route>
         <Route path="/nest">
           <React17 />
+        </Route>
+        <Route path="/font">
+          <Font />
         </Route>
         <Route exact path="/">
           <Redirect to="/home" />

--- a/examples/react16/src/Font.js
+++ b/examples/react16/src/Font.js
@@ -1,0 +1,34 @@
+import React from "react";
+import { IconFont } from "tdesign-icons-react";
+
+export default class Font extends React.Component {
+  componentDidMount() {
+    console.log("react16 font mounted")
+  }
+  render() {
+    return (
+      <div>
+        <h2>字体处理</h2>
+        <div className="content">
+          <h3>背景</h3>
+          <p>
+            子应用的 dom 挂载在 Web Component 的 shadowRoot 内，
+            <a href="https://github.com/mdn/interactive-examples/issues/887" target="_blank" rel="noreferrer">
+              shadowRoot 内部的字体文件不会加载
+            </a>
+          </p>
+          <h3>解决</h3>
+          <p>
+            框架加载子应用时将自定义字体样式提取到 shadowRoot 的外部，注意主应用和子应用的 @font-face 的 font-family
+            不要重名，否则会有字体覆盖的问题。
+          </p>
+          <h3>IconFont 图标示例</h3>
+          <p>TDesign icon</p>
+          <IconFont name="loading" size="2em" />
+          <IconFont name="close" size="2em" />
+          <IconFont name="check-circle-filled" size="2em" />
+        </div>
+      </div>
+    );
+  }
+}

--- a/packages/wujie-core/__test__/integration/common.ts
+++ b/packages/wujie-core/__test__/integration/common.ts
@@ -17,6 +17,8 @@ export const reactMainAppInfoMap = {
     routeMountedMessage: "react16 location mounted",
     communicationNavSelectorInAll: `document.querySelector("#root > div > div.content > div > div:nth-child(1) > div > wujie-app").shadowRoot.querySelector("#root > div > nav > a:nth-child(4)")`,
     nestNavSelectorInAll: `document.querySelector("#root > div > div.content > div > div:nth-child(1) > div > wujie-app").shadowRoot.querySelector("#root > div > nav > a:nth-child(5)")`,
+    fontNavSelector: `document.querySelector("#root > div > div.content > div > wujie-app").shadowRoot.querySelector("#root > div > nav > a:nth-child(6)")`,
+    fontMountedMessage: `react16 font mounted`,
     preloadTitleJsSelector: 'window.frames.react16.document.querySelector("#root > div > div:nth-child(3) > h2")',
     degradeTitleJsSelector: `window.document.querySelector("iframe[data-wujie-id='react16']").contentDocument.querySelector("#root > div > div:nth-child(3) > h2")`,
     titleJsSelector:
@@ -153,6 +155,8 @@ export const vueMainAppInfoMap = {
     routeMountedMessage: "react16 location mounted",
     communicationNavSelectorInAll: `document.querySelector("#app > div.content > div > div:nth-child(1) > wujie-app").shadowRoot.querySelector("#root > div > nav > a:nth-child(4)")`,
     nestNavSelectorInAll: `document.querySelector("#app > div.content > div > div:nth-child(1) > wujie-app").shadowRoot.querySelector("#root > div > nav > a:nth-child(5)")`,
+    fontNavSelector: `document.querySelector("#app > div.content > div > wujie-app").shadowRoot.querySelector("#root > div > nav > a:nth-child(6)")`,
+    fontMountedMessage: `react16 font mounted`,
     preloadTitleJsSelector: 'window.frames.react16.document.querySelector("#root > div > div:nth-child(3) > h2")',
     degradeTitleJsSelector: `window.document.querySelector("iframe[data-wujie-id='react16']").contentDocument.querySelector("#root > div > div:nth-child(3) > h2")`,
     titleJsSelector:

--- a/packages/wujie-core/__test__/integration/font.test.ts
+++ b/packages/wujie-core/__test__/integration/font.test.ts
@@ -1,0 +1,57 @@
+import { awaitConsoleLogMessage, triggerClickByJsSelector } from "./utils";
+import { reactMainAppInfoMap, vueMainAppInfoMap } from "./common";
+
+describe("main react startApp", () => {
+  beforeAll(async () => {
+    await page.evaluateOnNewDocument(() => {
+      // 关闭预加载
+      localStorage.clear();
+      localStorage.setItem("preload", "false");
+      localStorage.setItem("degrade", "false");
+    });
+    await page.goto("http://localhost:7700/");
+  });
+  it("check react16 font-face", async () => {
+    const appInfo = reactMainAppInfoMap.react16;
+    const appInfoMountedPromise = awaitConsoleLogMessage(page, appInfo.mountedMessage);
+    expect(await page.evaluate(() => document.fonts.check("12px t", "E07F"))).toBe(false);
+    await page.click(appInfo.linkSelector);
+    await appInfoMountedPromise;
+    const appInfoFontMountedPromise = awaitConsoleLogMessage(page, appInfo.fontMountedMessage);
+    await triggerClickByJsSelector(page, appInfo.fontNavSelector);
+    await appInfoFontMountedPromise;
+    // 等待字体加载
+    await page.waitForResponse((response) => response.url().includes("https://tdesign.gtimg.com/icon/0.1.1/fonts"));
+    // 等待字体装载
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    // 检查字体是否生效
+    expect(await page.evaluate(() => document.fonts.check("12px t", "E07F"))).toBe(true);
+  });
+});
+describe("main vue startApp", () => {
+  beforeAll(async () => {
+    await page.evaluateOnNewDocument(() => {
+      // 关闭预加载
+      localStorage.clear();
+      localStorage.setItem("preload", "false");
+      localStorage.setItem("degrade", "false");
+    });
+    await page.goto("http://localhost:8000/");
+  });
+  it("check react16 font-face", async () => {
+    const appInfo = vueMainAppInfoMap.react16;
+    const appInfoMountedPromise = awaitConsoleLogMessage(page, appInfo.mountedMessage);
+    expect(await page.evaluate(() => document.fonts.check("12px t", "E07F"))).toBe(false);
+    await page.click(appInfo.linkSelector);
+    await appInfoMountedPromise;
+    const appInfoFontMountedPromise = awaitConsoleLogMessage(page, appInfo.fontMountedMessage);
+    await triggerClickByJsSelector(page, appInfo.fontNavSelector);
+    await appInfoFontMountedPromise;
+    // 等待字体加载
+    await page.waitForResponse((response) => response.url().includes("https://tdesign.gtimg.com/icon/0.1.1/fonts"));
+    // 等待字体装载
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    // 检查字体是否生效
+    expect(await page.evaluate(() => document.fonts.check("12px t", "E07F"))).toBe(true);
+  });
+});

--- a/packages/wujie-core/jest-puppeteer.config.js
+++ b/packages/wujie-core/jest-puppeteer.config.js
@@ -48,7 +48,7 @@ module.exports = {
       port: 7400,
     },
     {
-      command: 'lerna run start --scope main-react',
+      command: 'lerna run integration --scope main-react',
       usedPortAction: 'kill',
       launchTimeout: 60000,
       host: '0.0.0.0',

--- a/packages/wujie-core/src/utils.ts
+++ b/packages/wujie-core/src/utils.ts
@@ -170,6 +170,10 @@ export function fixElementCtrSrcOrHref(
   // TODO: innerHTML的处理
 }
 
+export function getCurUrl(proxyLocation: Location): string {
+  return proxyLocation.protocol + "//" + proxyLocation.host + proxyLocation.pathname;
+}
+
 /**
  * 获取需要同步的url
  */

--- a/packages/wujie-doc/docs/question/README.md
+++ b/packages/wujie-doc/docs/question/README.md
@@ -38,7 +38,7 @@ ctx.set("Access-Control-Allow-Origin", ctx.headers.origin);
 
 **原因：** `@font-face`不会在`shadow`内部加载，[详见](https://github.com/mdn/interactive-examples/issues/887)
 
-**解决方案：** 将子应用需要到的`@font-face`在主应用进行加载
+**解决方案：** 框架已解决，会将子应用的`@font-face`放到`shadow`外部执行，注意子应用的自定义字体名和主应用的自定义字体名不能重复，否则可能存在覆盖问题
 
 ## 4、冒泡系列组件（比如下拉框）弹出位置不正确
 


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [x] 文档更改
- [x] 测试用例添加
- [x] `npm run test`通过

##### 详细描述

- 框架将子应用的`@font-face`放到`shadow`外部执行，注意子应用的自定义字体名和主应用的自定义字体名不能重复否则可能覆盖
- 关联issue #28
