### PR TITLE
fix: 修复子应用window.window指向问题

### DIFF
--- a/packages/wujie-core/src/proxy.ts
+++ b/packages/wujie-core/src/proxy.ts
@@ -45,8 +45,8 @@ export function proxyGenerator(
       if (p === "location") {
         return target.__WUJIE.proxyLocation;
       }
-      // self.self === self
-      if (p === "self") {
+      // 判断自身
+      if (p === "self" || p === "window") {
         return target.__WUJIE.proxy;
       }
       // 不要绑定this


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [x] `npm run test`通过

##### 详细描述

- 特性
子应用的 window.window !== window 导致在 zepto.js 中调用 $(window).width() 出错，修复了window.window === window 这个判断
- 关联issue 
#40 