### PR TITLE
feat: 添加createApp全局配置缓存

### DIFF
--- a/examples/main-react/src/index.js
+++ b/examples/main-react/src/index.js
@@ -12,70 +12,104 @@ import credentialsFetch from "./fetch";
 import lifecycles from "./lifecycle";
 import plugins from "./plugin";
 
-const { preloadApp, bus } = WujieReact;
+const { createApp, preloadApp, bus } = WujieReact;
 const isProduction = process.env.NODE_ENV === "production";
 bus.$on("click", (msg) => window.alert(msg));
 
+const degrade = window.localStorage.getItem("degrade") === "true" || !window.Proxy || !window.CustomElementRegistry;
+// 创建应用，主要是设置配置，preloadApp、startApp的配置基于这个配置做覆盖
+createApp({
+  name: "react16",
+  url: hostMap("//localhost:7600/"),
+  attrs: isProduction ? { src: hostMap("//localhost:7600/") } : {},
+  exec: true,
+  fetch: credentialsFetch,
+  plugins,
+  prefix: { "prefix-dialog": "/dialog", "prefix-location": "/location" },
+  degrade,
+  // 修正iframe的url，防止github pages csp报错
+  react16Attrs: process.env.NODE_ENV === "production" ? { src: hostMap("//localhost:7600/") } : {},
+  ...lifecycles,
+});
+
+createApp({
+  name: "react17",
+  url: hostMap("//localhost:7100/"),
+  attrs: isProduction ? { src: hostMap("//localhost:7100/") } : {},
+  exec: true,
+  alive: true,
+  fetch: credentialsFetch,
+  degrade,
+  react17Attrs: process.env.NODE_ENV === "production" ? { src: hostMap("//localhost:7100/") } : {},
+  ...lifecycles,
+});
+
+createApp({
+  name: "vue2",
+  url: hostMap("//localhost:7200/"),
+  attrs: isProduction ? { src: hostMap("//localhost:7200/") } : {},
+  exec: true,
+  fetch: credentialsFetch,
+  degrade,
+  vue2Attrs: process.env.NODE_ENV === "production" ? { src: hostMap("//localhost:7200/") } : {},
+  ...lifecycles,
+});
+
+createApp({
+  name: "vue3",
+  url: hostMap("//localhost:7300/"),
+  attrs: isProduction ? { src: hostMap("//localhost:7300/") } : {},
+  exec: true,
+  alive: true,
+  plugins: [{ cssExcludes: ["https://stackpath.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"] }],
+  // 引入了的第三方样式不需要添加credentials
+  fetch: (url, options) =>
+    url.includes(hostMap("//localhost:7300/")) ? credentialsFetch(url, options) : window.fetch(url, options),
+  degrade,
+  vue3Attrs: process.env.NODE_ENV === "production" ? { src: hostMap("//localhost:7300/") } : {},
+  ...lifecycles,
+});
+
+createApp({
+  name: "angular12",
+  url: hostMap("//localhost:7400/"),
+  attrs: isProduction ? { src: hostMap("//localhost:7400/") } : {},
+  exec: true,
+  fetch: credentialsFetch,
+  degrade,
+  angular12Attrs: process.env.NODE_ENV === "production" ? { src: hostMap("//localhost:7400/") } : {},
+  ...lifecycles,
+});
+
+createApp({
+  name: "vite",
+  url: hostMap("//localhost:7500/"),
+  attrs: isProduction ? { src: hostMap("//localhost:7500/") } : {},
+  exec: true,
+  fetch: credentialsFetch,
+  degrade,
+  viteAttrs: process.env.NODE_ENV === "production" ? { src: hostMap("//localhost:7500/") } : {},
+  ...lifecycles,
+});
+
 if (window.localStorage.getItem("preload") !== "false") {
-  const degrade = window.localStorage.getItem("degrade") === "true" || !window.Proxy || !window.CustomElementRegistry;
   preloadApp({
     name: "react16",
-    url: hostMap("//localhost:7600/"),
-    attrs: isProduction ? {src: hostMap("//localhost:7600/")} : {},
-    exec: true,
-    fetch: credentialsFetch,
-    degrade,
-    plugins,
-    ...lifecycles,
   });
   preloadApp({
     name: "react17",
-    url: hostMap("//localhost:7100/"),
-    attrs: isProduction ? {src: hostMap("//localhost:7100/")} : {},
-    exec: true,
-    alive: true,
-    fetch: credentialsFetch,
-    degrade,
-    ...lifecycles,
   });
   preloadApp({
     name: "vue2",
-    url: hostMap("//localhost:7200/"),
-    attrs: isProduction ? {src: hostMap("//localhost:7200/")} : {},
-    exec: true,
-    fetch: credentialsFetch,
-    degrade,
-    ...lifecycles,
   });
   preloadApp({
     name: "vue3",
-    url: hostMap("//localhost:7300/"),
-    attrs: isProduction ? {src: hostMap("//localhost:7300/")} : {},
-    exec: true,
-    alive: true,
-    // 引入了的第三方样式不需要添加credentials
-    fetch: (url, options) =>
-      url.includes(hostMap("//localhost:7300/")) ? credentialsFetch(url, options) : window.fetch(url, options),
-    degrade,
-    ...lifecycles,
   });
   preloadApp({
     name: "angular12",
-    url: hostMap("//localhost:7400/"),
-    attrs: isProduction ? {src: hostMap("//localhost:7400/")} : {},
-    exec: true,
-    fetch: credentialsFetch,
-    degrade,
-    ...lifecycles,
   });
   preloadApp({
     name: "vite",
-    url: hostMap("//localhost:7500/"),
-    attrs: isProduction ? {src: hostMap("//localhost:7500/")} : {},
-    exec: true,
-    fetch: credentialsFetch,
-    degrade,
-    ...lifecycles,
   });
 }
 

--- a/examples/main-react/src/pages/All.js
+++ b/examples/main-react/src/pages/All.js
@@ -1,9 +1,7 @@
 import React from "react";
 import hostMap from "../hostMap";
-import fetch from "../fetch";
 import WujieReact from "wujie-react";
 import { useNavigate } from "react-router-dom";
-import lifecycles from "../lifecycle";
 
 export default function React16() {
   const navigation = useNavigate();
@@ -14,15 +12,6 @@ export default function React16() {
   const vite = hostMap("//localhost:7500/");
   const angular12Url = hostMap("//localhost:7400/");
   // 修正iframe的url，防止github pages csp报错
-  const react16Attrs = process.env.NODE_ENV === "production" ? { src: react16Url } : {};
-  const react17Attrs = process.env.NODE_ENV === "production" ? { src: react17Url } : {};
-  const vue2Attrs = process.env.NODE_ENV === "production" ? { src: vue2Url } : {};
-  const vue3Attrs = process.env.NODE_ENV === "production" ? { src: vue3Url } : {};
-  const viteAttrs = process.env.NODE_ENV === "production" ? { src: vite } : {};
-  const angular12Attrs = process.env.NODE_ENV === "production" ? { src: angular12Url } : {};
-  const degrade = window.localStorage.getItem("degrade") === "true";
-  const vue3Fetch = (url, options) =>
-    url.includes(hostMap("//localhost:7300/")) ? fetch(url, options) : window.fetch(url, options);
   const props = {
     jump: (name) => {
       navigation(`/${name}`);
@@ -37,19 +26,7 @@ export default function React16() {
           name="react16"
           url={react16Url}
           sync={true}
-          fetch={fetch}
           props={props}
-          attrs={react16Attrs}
-          degrade={degrade}
-          prefix={{ "prefix-dialog": "/dialog", "prefix-location": "/location" }}
-          beforeLoad={lifecycles.beforeLoad}
-          beforeMount={lifecycles.beforeMount}
-          afterMount={lifecycles.afterMount}
-          beforeUnmount={lifecycles.beforeUnmount}
-          afterUnmount={lifecycles.afterUnmount}
-          activated={lifecycles.activated}
-          deactivated={lifecycles.deactivated}
-          loadError={lifecycles.loadError}
         ></WujieReact>
       </div>
       <div className="all-item">
@@ -59,19 +36,8 @@ export default function React16() {
           name="react17"
           url={react17Url}
           sync={true}
-          fetch={fetch}
           props={props}
-          attrs={react17Attrs}
           alive={true}
-          degrade={degrade}
-          beforeLoad={lifecycles.beforeLoad}
-          beforeMount={lifecycles.beforeMount}
-          afterMount={lifecycles.afterMount}
-          beforeUnmount={lifecycles.beforeUnmount}
-          afterUnmount={lifecycles.afterUnmount}
-          activated={lifecycles.activated}
-          deactivated={lifecycles.deactivated}
-          loadError={lifecycles.loadError}
         ></WujieReact>
       </div>
       <div className="all-item">
@@ -81,18 +47,7 @@ export default function React16() {
           name="vue2"
           url={vue2Url}
           sync={true}
-          fetch={fetch}
           props={props}
-          attrs={vue2Attrs}
-          degrade={degrade}
-          beforeLoad={lifecycles.beforeLoad}
-          beforeMount={lifecycles.beforeMount}
-          afterMount={lifecycles.afterMount}
-          beforeUnmount={lifecycles.beforeUnmount}
-          afterUnmount={lifecycles.afterUnmount}
-          activated={lifecycles.activated}
-          deactivated={lifecycles.deactivated}
-          loadError={lifecycles.loadError}
         ></WujieReact>
       </div>
       <div className="all-item">
@@ -102,19 +57,8 @@ export default function React16() {
           name="vue3"
           url={vue3Url}
           sync={true}
-          fetch={vue3Fetch}
           props={props}
-          attrs={vue3Attrs}
           alive={true}
-          degrade={degrade}
-          beforeLoad={lifecycles.beforeLoad}
-          beforeMount={lifecycles.beforeMount}
-          afterMount={lifecycles.afterMount}
-          beforeUnmount={lifecycles.beforeUnmount}
-          afterUnmount={lifecycles.afterUnmount}
-          activated={lifecycles.activated}
-          deactivated={lifecycles.deactivated}
-          loadError={lifecycles.loadError}
         ></WujieReact>
       </div>
       <div className="all-item">
@@ -124,18 +68,7 @@ export default function React16() {
           name="vite"
           url={vite}
           sync={true}
-          fetch={fetch}
           props={props}
-          attrs={viteAttrs}
-          degrade={degrade}
-          beforeLoad={lifecycles.beforeLoad}
-          beforeMount={lifecycles.beforeMount}
-          afterMount={lifecycles.afterMount}
-          beforeUnmount={lifecycles.beforeUnmount}
-          afterUnmount={lifecycles.afterUnmount}
-          activated={lifecycles.activated}
-          deactivated={lifecycles.deactivated}
-          loadError={lifecycles.loadError}
         ></WujieReact>
       </div>
       <div className="all-item">
@@ -145,18 +78,7 @@ export default function React16() {
           name="angular12"
           url={angular12Url}
           sync={true}
-          fetch={fetch}
           props={props}
-          attrs={angular12Attrs}
-          degrade={degrade}
-          beforeLoad={lifecycles.beforeLoad}
-          beforeMount={lifecycles.beforeMount}
-          afterMount={lifecycles.afterMount}
-          beforeUnmount={lifecycles.beforeUnmount}
-          afterUnmount={lifecycles.afterUnmount}
-          activated={lifecycles.activated}
-          deactivated={lifecycles.deactivated}
-          loadError={lifecycles.loadError}
         ></WujieReact>
       </div>
     </div>

--- a/examples/main-react/src/pages/Angular12.js
+++ b/examples/main-react/src/pages/Angular12.js
@@ -1,16 +1,11 @@
 import React from "react";
 import hostMap from "../hostMap";
-import fetch from "../fetch";
 import WujieReact from "wujie-react";
 import { useNavigate } from "react-router-dom";
-import lifecycles from "../lifecycle";
 
 export default function Angular12() {
   const navigation = useNavigate();
   const angular12Url = hostMap("//localhost:7400/");
-  const degrade = window.localStorage.getItem("degrade") === "true";
-  // 修正iframe的url，防止github pages csp报错
-  const attrs = process.env.NODE_ENV === "production" ? { src: angular12Url } : {};
   const props = {
     jump: (name) => {
       navigation(`/${name}`);
@@ -23,18 +18,7 @@ export default function Angular12() {
       name="angular12"
       url={angular12Url}
       sync={true}
-      fetch={fetch}
       props={props}
-      attrs={attrs}
-      degrade={degrade}
-      beforeLoad={lifecycles.beforeLoad}
-      beforeMount={lifecycles.beforeMount}
-      afterMount={lifecycles.afterMount}
-      beforeUnmount={lifecycles.beforeUnmount}
-      afterUnmount={lifecycles.afterUnmount}
-      activated={lifecycles.activated}
-      deactivated={lifecycles.deactivated}
-      loadError={lifecycles.loadError}
     ></WujieReact>
   );
 }

--- a/examples/main-react/src/pages/React16.js
+++ b/examples/main-react/src/pages/React16.js
@@ -1,19 +1,13 @@
 import React from "react";
 import hostMap from "../hostMap";
-import fetch from "../fetch";
 import WujieReact from "wujie-react";
 import { useNavigate, useLocation } from "react-router-dom";
-import lifecycles from "../lifecycle";
-import plugins from "../plugin";
 
 export default function React16() {
   const navigation = useNavigate();
   const location = useLocation();
   const path = location.pathname.replace("/react16-sub", "").replace("/react16", "").replace("/",""); ////
   const react16Url = hostMap("//localhost:7600/") + path;
-  const degrade = window.localStorage.getItem("degrade") === "true";
-  // 修正iframe的url，防止github pages csp报错
-  const attrs = process.env.NODE_ENV === "production" ? { src: react16Url } : {};
   const props = {
     jump: (name) => {
       navigation(`/${name}`);
@@ -27,20 +21,7 @@ export default function React16() {
       name="react16"
       url={react16Url}
       sync={true}
-      fetch={fetch}
       props={props}
-      degrade={degrade}
-      plugins={plugins}
-      attrs={attrs}
-      prefix={{ "prefix-dialog": "/dialog", "prefix-location": "/location" }}
-      beforeLoad={lifecycles.beforeLoad}
-      beforeMount={lifecycles.beforeMount}
-      afterMount={lifecycles.afterMount}
-      beforeUnmount={lifecycles.beforeUnmount}
-      afterUnmount={lifecycles.afterUnmount}
-      activated={lifecycles.activated}
-      deactivated={lifecycles.deactivated}
-      loadError={lifecycles.loadError}
     ></WujieReact>
   );
 }

--- a/examples/main-react/src/pages/React17.js
+++ b/examples/main-react/src/pages/React17.js
@@ -1,9 +1,7 @@
 import React from "react";
 import hostMap from "../hostMap";
-import fetch from "../fetch";
 import WujieReact from "wujie-react";
 import { useNavigate, useLocation } from "react-router-dom";
-import lifecycles from "../lifecycle";
 
 export default function React17() {
   const location = useLocation();
@@ -11,10 +9,7 @@ export default function React17() {
   const react17Url = hostMap("//localhost:7100/");
   const path = location.pathname.replace("/react17-sub", "").replace("/react17", "");////
   // 告诉子应用要跳转哪个路由
-  WujieReact.bus.$emit("react17-router-change", path);
-  const degrade = window.localStorage.getItem("degrade") === "true";
-  // 修正iframe的url，防止github pages csp报错
-  const attrs = process.env.NODE_ENV === "production" ? { src: react17Url } : {};
+  path && WujieReact.bus.$emit("react17-router-change", path);
   const props = {
     jump: (name) => {
       navigation(`/${name}`);
@@ -27,20 +22,8 @@ export default function React17() {
       height="100%"
       name="react17"
       url={react17Url}
-      alive={true}
       sync={true}
-      fetch={fetch}
       props={props}
-      attrs={attrs}
-      degrade={degrade}
-      beforeLoad={lifecycles.beforeLoad}
-      beforeMount={lifecycles.beforeMount}
-      afterMount={lifecycles.afterMount}
-      beforeUnmount={lifecycles.beforeUnmount}
-      afterUnmount={lifecycles.afterUnmount}
-      activated={lifecycles.activated}
-      deactivated={lifecycles.deactivated}
-      loadError={lifecycles.loadError}
     ></WujieReact>
   );
 }

--- a/examples/main-react/src/pages/Vite.js
+++ b/examples/main-react/src/pages/Vite.js
@@ -1,18 +1,13 @@
 import React from "react";
 import hostMap from "../hostMap";
-import fetch from "../fetch";
 import WujieReact from "wujie-react";
 import { useNavigate, useLocation } from "react-router-dom";
-import lifecycles from "../lifecycle";
 
 export default function Vite() {
   const location = useLocation();
   const navigation = useNavigate();
   const path = location.pathname.replace("/vite-sub", "").replace("/vite", "").replace("/", "");////
   const viteUrl = hostMap("//localhost:7500/") + path;
-  const degrade = window.localStorage.getItem("degrade") === "true";
-  // 修正iframe的url，防止github pages csp报错
-  const attrs = process.env.NODE_ENV === "production" ? { src: viteUrl } : {};
   const props = {
     jump: (name) => {
       navigation(`/${name}`);
@@ -26,18 +21,7 @@ export default function Vite() {
       name="vite"
       url={viteUrl}
       sync={true}
-      fetch={fetch}
       props={props}
-      attrs={attrs}
-      degrade={degrade}
-      beforeLoad={lifecycles.beforeLoad}
-      beforeMount={lifecycles.beforeMount}
-      afterMount={lifecycles.afterMount}
-      beforeUnmount={lifecycles.beforeUnmount}
-      afterUnmount={lifecycles.afterUnmount}
-      activated={lifecycles.activated}
-      deactivated={lifecycles.deactivated}
-      loadError={lifecycles.loadError}
     ></WujieReact>
   );
 }

--- a/examples/main-react/src/pages/Vue2.js
+++ b/examples/main-react/src/pages/Vue2.js
@@ -1,18 +1,13 @@
 import React from "react";
 import hostMap from "../hostMap";
-import fetch from "../fetch";
 import WujieReact from "wujie-react";
 import { useNavigate, useLocation } from "react-router-dom";
-import lifecycles from "../lifecycle";
 
 export default function Vue2() {
   const location = useLocation();
   const navigation = useNavigate();
   const path = location.pathname.replace("/vue2-sub", "").replace("/vue2", "");////
   const vue2Url = hostMap("//localhost:7200/") + "#" + path;
-  const degrade = window.localStorage.getItem("degrade") === "true";
-  // 修正iframe的url，防止github pages csp报错
-  const attrs = process.env.NODE_ENV === "production" ? { src: vue2Url } : {};
   const props = {
     jump: (name) => {
       navigation(`/${name}`);
@@ -26,18 +21,7 @@ export default function Vue2() {
       name="vue2"
       url={vue2Url}
       sync={true}
-      fetch={fetch}
       props={props}
-      degrade={degrade}
-      attrs={attrs}
-      beforeLoad={lifecycles.beforeLoad}
-      beforeMount={lifecycles.beforeMount}
-      afterMount={lifecycles.afterMount}
-      beforeUnmount={lifecycles.beforeUnmount}
-      afterUnmount={lifecycles.afterUnmount}
-      activated={lifecycles.activated}
-      deactivated={lifecycles.deactivated}
-      loadError={lifecycles.loadError}
     ></WujieReact>
   );
 }

--- a/examples/main-react/src/pages/Vue3.js
+++ b/examples/main-react/src/pages/Vue3.js
@@ -1,9 +1,7 @@
 import React from "react";
 import hostMap from "../hostMap";
-import fetch from "../fetch";
 import WujieReact from "wujie-react";
 import { useNavigate, useLocation } from "react-router-dom";
-import lifecycles from "../lifecycle";
 
 export default function Vue3() {
   const location = useLocation();
@@ -11,12 +9,7 @@ export default function Vue3() {
   const path = location.pathname.replace("/vue3-sub", "").replace("/vue3", "");////
   const vue3Url = hostMap("//localhost:7300/");
     // 告诉子应用要跳转哪个路由
-    WujieReact.bus.$emit("vue3-router-change", path);
-  const degrade = window.localStorage.getItem("degrade") === "true";
-  // 修正iframe的url，防止github pages csp报错
-  const attrs = process.env.NODE_ENV === "production" ? { src: vue3Url } : {};
-  const customFetch = (url, options) =>
-    url.includes(hostMap("//localhost:7300/")) ? fetch(url, options) : window.fetch(url, options);
+  path && WujieReact.bus.$emit("vue3-router-change", path);
   const props = {
     jump: (name) => {
       navigation(`/${name}`);
@@ -29,20 +22,7 @@ export default function Vue3() {
       name="vue3"
       url={vue3Url}
       sync={true}
-      alive={true}
-      fetch={customFetch}
       props={props}
-      attrs={attrs}
-      degrade={degrade}
-      plugins={[{ cssExcludes: ['https://stackpath.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css'] }]}
-      beforeLoad={lifecycles.beforeLoad}
-      beforeMount={lifecycles.beforeMount}
-      afterMount={lifecycles.afterMount}
-      beforeUnmount={lifecycles.beforeUnmount}
-      afterUnmount={lifecycles.afterUnmount}
-      activated={lifecycles.activated}
-      deactivated={lifecycles.deactivated}
-      loadError={lifecycles.loadError}
     ></WujieReact>
   );
 }

--- a/examples/main-vue/src/main.js
+++ b/examples/main-vue/src/main.js
@@ -17,73 +17,118 @@ import lifecycles from "./lifecycle";
 import plugins from "./plugin";
 
 const isProduction = process.env.NODE_ENV === "production";
-const { preloadApp, bus } = WujieVue;
+const { createApp, preloadApp, bus } = WujieVue;
 Vue.use(WujieVue).use(Switch).use(Tooltip).use(button).use(Icon);
 
 Vue.config.productionTip = false;
 
 bus.$on("click", (msg) => window.alert(msg));
 
+const degrade = window.localStorage.getItem("degrade") === "true" || !window.Proxy || !window.CustomElementRegistry;
+const props = {
+  jump: (name) => {
+    router.push({ name });
+  },
+};
+// 创建应用，主要是设置配置，preloadApp、startApp的配置基于这个配置做覆盖
+createApp({
+  name: "react16",
+  url: hostMap("//localhost:7600/"),
+  attrs: isProduction ? { src: hostMap("//localhost:7600/") } : {},
+  exec: true,
+  props,
+  fetch: credentialsFetch,
+  plugins,
+  prefix: { "prefix-dialog": "/dialog", "prefix-location": "/location" },
+  degrade,
+  // 修正iframe的url，防止github pages csp报错
+  react16Attrs: process.env.NODE_ENV === "production" ? { src: hostMap("//localhost:7600/") } : {},
+  ...lifecycles,
+});
+
+createApp({
+  name: "react17",
+  url: hostMap("//localhost:7100/"),
+  attrs: isProduction ? { src: hostMap("//localhost:7100/") } : {},
+  exec: true,
+  alive: true,
+  props,
+  fetch: credentialsFetch,
+  degrade,
+  react17Attrs: process.env.NODE_ENV === "production" ? { src: hostMap("//localhost:7100/") } : {},
+  ...lifecycles,
+});
+
+createApp({
+  name: "vue2",
+  url: hostMap("//localhost:7200/"),
+  attrs: isProduction ? { src: hostMap("//localhost:7200/") } : {},
+  exec: true,
+  props,
+  fetch: credentialsFetch,
+  degrade,
+  vue2Attrs: process.env.NODE_ENV === "production" ? { src: hostMap("//localhost:7200/") } : {},
+  ...lifecycles,
+});
+
+createApp({
+  name: "vue3",
+  url: hostMap("//localhost:7300/"),
+  attrs: isProduction ? { src: hostMap("//localhost:7300/") } : {},
+  exec: true,
+  alive: true,
+  plugins: [{ cssExcludes: ["https://stackpath.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"] }],
+  props,
+  // 引入了的第三方样式不需要添加credentials
+  fetch: (url, options) =>
+    url.includes(hostMap("//localhost:7300/")) ? credentialsFetch(url, options) : window.fetch(url, options),
+  degrade,
+  vue3Attrs: process.env.NODE_ENV === "production" ? { src: hostMap("//localhost:7300/") } : {},
+  ...lifecycles,
+});
+
+createApp({
+  name: "angular12",
+  url: hostMap("//localhost:7400/"),
+  attrs: isProduction ? { src: hostMap("//localhost:7400/") } : {},
+  exec: true,
+  props,
+  fetch: credentialsFetch,
+  degrade,
+  angular12Attrs: process.env.NODE_ENV === "production" ? { src: hostMap("//localhost:7400/") } : {},
+  ...lifecycles,
+});
+
+createApp({
+  name: "vite",
+  url: hostMap("//localhost:7500/"),
+  attrs: isProduction ? { src: hostMap("//localhost:7500/") } : {},
+  exec: true,
+  props,
+  fetch: credentialsFetch,
+  degrade,
+  viteAttrs: process.env.NODE_ENV === "production" ? { src: hostMap("//localhost:7500/") } : {},
+  ...lifecycles,
+});
+
 if (window.localStorage.getItem("preload") !== "false") {
-  const degrade = window.localStorage.getItem("degrade") === "true" || !window.Proxy || !window.CustomElementRegistry;
   preloadApp({
     name: "react16",
-    url: hostMap("//localhost:7600/"),
-    attrs: isProduction ? { src: hostMap("//localhost:7600/") } : {},
-    exec: true,
-    fetch: credentialsFetch,
-    degrade,
-    plugins,
-    ...lifecycles,
   });
   preloadApp({
     name: "react17",
-    url: hostMap("//localhost:7100/"),
-    attrs: isProduction ? { src: hostMap("//localhost:7100/") } : {},
-    exec: true,
-    alive: true,
-    fetch: credentialsFetch,
-    degrade,
-    ...lifecycles,
   });
   preloadApp({
     name: "vue2",
-    url: hostMap("//localhost:7200/"),
-    attrs: isProduction ? { src: hostMap("//localhost:7200/") } : {},
-    exec: true,
-    fetch: credentialsFetch,
-    degrade,
-    ...lifecycles,
   });
   preloadApp({
     name: "vue3",
-    url: hostMap("//localhost:7300/"),
-    attrs: isProduction ? { src: hostMap("//localhost:7300/") } : {},
-    exec: true,
-    alive: true,
-    // 引入了的第三方样式不需要添加credentials
-    fetch: (url, options) =>
-      url.includes(hostMap("//localhost:7300/")) ? credentialsFetch(url, options) : window.fetch(url, options),
-    degrade,
-    ...lifecycles,
   });
   preloadApp({
     name: "angular12",
-    url: hostMap("//localhost:7400/"),
-    attrs: isProduction ? { src: hostMap("//localhost:7400/") } : {},
-    exec: true,
-    fetch: credentialsFetch,
-    degrade,
-    ...lifecycles,
   });
   preloadApp({
     name: "vite",
-    url: hostMap("//localhost:7500/"),
-    attrs: isProduction ? { src: hostMap("//localhost:7500/") } : {},
-    exec: true,
-    fetch: credentialsFetch,
-    degrade,
-    ...lifecycles,
   });
 }
 

--- a/examples/main-vue/src/views/Angular12.vue
+++ b/examples/main-vue/src/views/Angular12.vue
@@ -1,27 +1,9 @@
 <template>
-  <WujieVue
-    class="angular-container"
-    name="angular12"
-    :url="url"
-    :attrs="attrs"
-    :fetch="fetch"
-    :sync="true"
-    :degrade="degrade"
-    :beforeLoad="lifecycles.beforeLoad"
-    :beforeMount="lifecycles.beforeMount"
-    :afterMount="lifecycles.afterMount"
-    :beforeUnmount="lifecycles.beforeUnmount"
-    :afterUnmount="lifecycles.afterUnmount"
-    :activated="lifecycles.activated"
-    :deactivated="lifecycles.deactivated"
-    :loadError="lifecycles.loadError"
-  ></WujieVue>
+  <WujieVue class="angular-container" name="angular12" :url="url" :attrs="attrs" :sync="true"></WujieVue>
 </template>
 
 <script>
 import hostMap from "../hostMap";
-import fetch from "../fetch";
-import lifecycles from "../lifecycle";
 
 export default {
   data() {
@@ -29,9 +11,6 @@ export default {
       url: hostMap("//localhost:7400/"),
       // 修正iframe的url，防止github pages csp报错
       attrs: process.env.NODE_ENV === "production" ? { src: hostMap("//localhost:7400/") } : {},
-      fetch,
-      degrade: window.localStorage.getItem("degrade") === "true",
-      lifecycles,
     };
   },
 };

--- a/examples/main-vue/src/views/Multiple.vue
+++ b/examples/main-vue/src/views/Multiple.vue
@@ -1,123 +1,16 @@
 <template>
   <div style="height: 100%; width: 100%">
-    <WujieVue
-      class="item"
-      name="react16"
-      :url="react16Url"
-      :sync="true"
-      :fetch="fetch"
-      :props="props"
-      :attrs="react16Attrs"
-      :degrade="degrade"
-      :prefix="{ 'prefix-dialog': '/dialog', 'prefix-location': '/location' }"
-      :beforeLoad="lifecycles.beforeLoad"
-      :beforeMount="lifecycles.beforeMount"
-      :afterMount="lifecycles.afterMount"
-      :beforeUnmount="lifecycles.beforeUnmount"
-      :afterUnmount="lifecycles.afterUnmount"
-      :activated="lifecycles.activated"
-      :deactivated="lifecycles.deactivated"
-      :loadError="lifecycles.loadError"
-    ></WujieVue>
-    <WujieVue
-      class="item"
-      name="react17"
-      :url="react17Url"
-      :sync="true"
-      :fetch="fetch"
-      :props="props"
-      :attrs="react17Attrs"
-      :degrade="degrade"
-      :alive="true"
-      :beforeLoad="lifecycles.beforeLoad"
-      :beforeMount="lifecycles.beforeMount"
-      :afterMount="lifecycles.afterMount"
-      :beforeUnmount="lifecycles.beforeUnmount"
-      :afterUnmount="lifecycles.afterUnmount"
-      :activated="lifecycles.activated"
-      :deactivated="lifecycles.deactivated"
-      :loadError="lifecycles.loadError"
-    ></WujieVue>
-    <WujieVue
-      class="item"
-      name="vue2"
-      :url="vue2Url"
-      :props="props"
-      :attrs="vue2Attrs"
-      :sync="true"
-      :fetch="fetch"
-      :degrade="degrade"
-      :beforeLoad="lifecycles.beforeLoad"
-      :beforeMount="lifecycles.beforeMount"
-      :afterMount="lifecycles.afterMount"
-      :beforeUnmount="lifecycles.beforeUnmount"
-      :afterUnmount="lifecycles.afterUnmount"
-      :activated="lifecycles.activated"
-      :deactivated="lifecycles.deactivated"
-      :loadError="lifecycles.loadError"
-    ></WujieVue>
-    <WujieVue
-      class="item"
-      name="vue3"
-      :url="vue3Url"
-      :sync="true"
-      :fetch="vue3Fetch"
-      :props="props"
-      :attrs="vue3Attrs"
-      :degrade="degrade"
-      :alive="true"
-      :beforeLoad="lifecycles.beforeLoad"
-      :beforeMount="lifecycles.beforeMount"
-      :afterMount="lifecycles.afterMount"
-      :beforeUnmount="lifecycles.beforeUnmount"
-      :afterUnmount="lifecycles.afterUnmount"
-      :activated="lifecycles.activated"
-      :deactivated="lifecycles.deactivated"
-      :loadError="lifecycles.loadError"
-    ></WujieVue>
-    <WujieVue
-      class="item"
-      name="vite"
-      :url="vite"
-      :sync="true"
-      :fetch="fetch"
-      :props="props"
-      :attrs="viteAttrs"
-      :degrade="degrade"
-      :beforeLoad="lifecycles.beforeLoad"
-      :beforeMount="lifecycles.beforeMount"
-      :afterMount="lifecycles.afterMount"
-      :beforeUnmount="lifecycles.beforeUnmount"
-      :afterUnmount="lifecycles.afterUnmount"
-      :activated="lifecycles.activated"
-      :deactivated="lifecycles.deactivated"
-      :loadError="lifecycles.loadError"
-    ></WujieVue>
-    <WujieVue
-      class="item"
-      name="angular12"
-      :url="angular12Url"
-      :sync="true"
-      :fetch="fetch"
-      :props="props"
-      :attrs="angular12Attrs"
-      :degrade="degrade"
-      :beforeLoad="lifecycles.beforeLoad"
-      :beforeMount="lifecycles.beforeMount"
-      :afterMount="lifecycles.afterMount"
-      :beforeUnmount="lifecycles.beforeUnmount"
-      :afterUnmount="lifecycles.afterUnmount"
-      :activated="lifecycles.activated"
-      :deactivated="lifecycles.deactivated"
-      :loadError="lifecycles.loadError"
-    ></WujieVue>
+    <WujieVue class="item" name="react16" :url="react16Url" :sync="true"></WujieVue>
+    <WujieVue class="item" name="react17" :url="react17Url" :sync="true"></WujieVue>
+    <WujieVue class="item" name="vue2" :url="vue2Url" :sync="true"></WujieVue>
+    <WujieVue class="item" name="vue3" :url="vue3Url" :sync="true"></WujieVue>
+    <WujieVue class="item" name="vite" :url="vite" :sync="true"></WujieVue>
+    <WujieVue class="item" name="angular12" :url="angular12Url" :sync="true"></WujieVue>
   </div>
 </template>
 
 <script>
 import hostMap from "../hostMap";
-import fetch from "../fetch";
-import lifecycles from "../lifecycle";
 
 export default {
   data() {
@@ -128,19 +21,6 @@ export default {
       vue3Url: hostMap("//localhost:7300/"),
       vite: hostMap("//localhost:7500/"),
       angular12Url: hostMap("//localhost:7400/"),
-      // 修正iframe的url，防止github pages csp报错
-      react16Attrs: process.env.NODE_ENV === "production" ? { src: hostMap("//localhost:7600/") } : {},
-      react17Attrs: process.env.NODE_ENV === "production" ? { src: hostMap("//localhost:7100/") } : {},
-      vue2Attrs: process.env.NODE_ENV === "production" ? { src: hostMap("//localhost:7200/") } : {},
-      vue3Attrs: process.env.NODE_ENV === "production" ? { src: hostMap("//localhost:7300/") } : {},
-      viteAttrs: process.env.NODE_ENV === "production" ? { src: hostMap("//localhost:7500/") } : {},
-      angular12Attrs: process.env.NODE_ENV === "production" ? { src: hostMap("//localhost:7400/") } : {},
-      props: { jump: this.jump },
-      degrade: window.localStorage.getItem("degrade") === "true",
-      fetch,
-      lifecycles,
-      vue3Fetch: (url, options) =>
-        url.includes(hostMap("//localhost:7300/")) ? fetch(url, options) : window.fetch(url, options),
     };
   },
   methods: {

--- a/examples/main-vue/src/views/React16.vue
+++ b/examples/main-vue/src/views/React16.vue
@@ -1,50 +1,16 @@
 <template>
   <!--单例模式，name相同则复用一个无界实例，改变url则子应用重新渲染实例到对应路由 -->
-  <WujieVue
-    width="100%"
-    height="100%"
-    name="react16"
-    :url="react16Url"
-    :sync="true"
-    :fetch="fetch"
-    :props="props"
-    :attrs="attrs"
-    :degrade="degrade"
-    :plugins="plugins"
-    :prefix="{ 'prefix-dialog': '/dialog', 'prefix-location': '/location' }"
-    :beforeLoad="lifecycles.beforeLoad"
-    :beforeMount="lifecycles.beforeMount"
-    :afterMount="lifecycles.afterMount"
-    :beforeUnmount="lifecycles.beforeUnmount"
-    :afterUnmount="lifecycles.afterUnmount"
-    :activated="lifecycles.activated"
-    :deactivated="lifecycles.deactivated"
-    :loadError="lifecycles.loadError"
-  ></WujieVue>
+  <WujieVue width="100%" height="100%" name="react16" :url="react16Url" :sync="true"></WujieVue>
 </template>
 
 <script>
 import hostMap from "../hostMap";
-import fetch from "../fetch";
-import lifecycles from "../lifecycle";
-import plugins from "../plugin";
+
 export default {
   data() {
     return {
       react16Url: hostMap("//localhost:7600/") + (this.$route.params.path ? `${this.$route.params.path}` : ""),
-      props: { jump: this.jump },
-      // 修正iframe的url，防止github pages csp报错
-      attrs: process.env.NODE_ENV === "production" ? { src: hostMap("//localhost:7600/") } : {},
-      fetch,
-      lifecycles,
-      degrade: window.localStorage.getItem("degrade") === "true",
-      plugins,
     };
-  },
-  methods: {
-    jump(name) {
-      this.$router.push({ name });
-    },
   },
 };
 </script>

--- a/examples/main-vue/src/views/React17.vue
+++ b/examples/main-vue/src/views/React17.vue
@@ -1,52 +1,20 @@
 <template>
   <!--保活模式，name相同则复用一个子应用实例，改变url无效，必须采用通信的方式告知路由变化 -->
-  <WujieVue
-    width="100%"
-    height="100%"
-    name="react17"
-    :url="react17Url"
-    :sync="true"
-    :alive="true"
-    :fetch="fetch"
-    :degrade="degrade"
-    :props="props"
-    :attrs="attrs"
-    :beforeLoad="lifecycles.beforeLoad"
-    :beforeMount="lifecycles.beforeMount"
-    :afterMount="lifecycles.afterMount"
-    :beforeUnmount="lifecycles.beforeUnmount"
-    :afterUnmount="lifecycles.afterUnmount"
-    :activated="lifecycles.activated"
-    :deactivated="lifecycles.deactivated"
-    :loadError="lifecycles.loadError"
-  ></WujieVue>
+  <WujieVue width="100%" height="100%" name="react17" :url="react17Url" :sync="true"></WujieVue>
 </template>
 
 <script>
 import hostMap from "../hostMap";
-import fetch from "../fetch";
-import lifecycles from "../lifecycle";
 import wujieVue from "wujie-vue2";
 export default {
   data() {
     return {
       react17Url: hostMap("//localhost:7100/"),
-      props: { jump: this.jump },
-      // 修正iframe的url，防止github pages csp报错
-      attrs: process.env.NODE_ENV === "production" ? { src: hostMap("//localhost:7100/") } : {},
-      fetch,
-      lifecycles,
-      degrade: window.localStorage.getItem("degrade") === "true",
     };
   },
   mounted() {
     // 告诉子应用要跳转哪个路由
     this.$route.params.path && wujieVue.bus.$emit("react17-router-change", `/${this.$route.params.path}`);
-  },
-  methods: {
-    jump(name) {
-      this.$router.push({ name });
-    },
   },
 };
 </script>

--- a/examples/main-vue/src/views/Vite.vue
+++ b/examples/main-vue/src/views/Vite.vue
@@ -1,47 +1,16 @@
 <template>
   <!--单例模式，name相同则复用一个无界实例，改变url则子应用重新渲染实例到对应路由 -->
-  <WujieVue
-    width="100%"
-    height="100%"
-    name="vite"
-    :url="viteUrl"
-    :sync="true"
-    :fetch="fetch"
-    :props="props"
-    :attrs="attrs"
-    :degrade="degrade"
-    :beforeLoad="lifecycles.beforeLoad"
-    :beforeMount="lifecycles.beforeMount"
-    :afterMount="lifecycles.afterMount"
-    :beforeUnmount="lifecycles.beforeUnmount"
-    :afterUnmount="lifecycles.afterUnmount"
-    :activated="lifecycles.activated"
-    :deactivated="lifecycles.deactivated"
-    :loadError="lifecycles.loadError"
-  ></WujieVue>
+  <WujieVue width="100%" height="100%" name="vite" :url="viteUrl" :sync="true"></WujieVue>
 </template>
 
 <script>
 import hostMap from "../hostMap";
-import fetch from "../fetch";
-import lifecycles from "../lifecycle";
 
 export default {
   data() {
     return {
       viteUrl: hostMap("//localhost:7500/") + (this.$route.params.path ? `${this.$route.params.path}` : ""),
-      fetch,
-      props: { jump: this.jump },
-      // 修正iframe的url，防止github pages csp报错
-      attrs: process.env.NODE_ENV === "production" ? { src: hostMap("//localhost:7500/") } : {},
-      degrade: window.localStorage.getItem("degrade") === "true",
-      lifecycles,
     };
-  },
-  methods: {
-    jump(name) {
-      this.$router.push({ name });
-    },
   },
 };
 </script>

--- a/examples/main-vue/src/views/Vue2.vue
+++ b/examples/main-vue/src/views/Vue2.vue
@@ -1,40 +1,15 @@
 <template>
   <!--单例模式，name相同则复用一个无界实例，改变url则子应用重新渲染实例到对应路由 -->
-  <WujieVue
-    width="100%"
-    height="100%"
-    name="vue2"
-    :url="vue2Url"
-    :props="props"
-    :attrs="attrs"
-    :sync="true"
-    :fetch="fetch"
-    :degrade="degrade"
-    :beforeLoad="lifecycles.beforeLoad"
-    :beforeMount="lifecycles.beforeMount"
-    :afterMount="lifecycles.afterMount"
-    :beforeUnmount="lifecycles.beforeUnmount"
-    :afterUnmount="lifecycles.afterUnmount"
-    :activated="lifecycles.activated"
-    :deactivated="lifecycles.deactivated"
-    :loadError="lifecycles.loadError"
-  ></WujieVue>
+  <WujieVue width="100%" height="100%" name="vue2" :url="vue2Url" :sync="true"></WujieVue>
 </template>
 
 <script>
 import hostMap from "../hostMap";
-import fetch from "../fetch";
-import lifecycles from "../lifecycle";
+
 export default {
   data() {
     return {
       vue2Url: hostMap("//localhost:7200/") + (this.$route.params.path ? `#/${this.$route.params.path}` : ""),
-      // 修正iframe的url，防止github pages csp报错
-      attrs: process.env.NODE_ENV === "production" ? { src: hostMap("//localhost:7200/") } : {},
-      props: { jump: this.jump },
-      fetch,
-      degrade: window.localStorage.getItem("degrade") === "true",
-      lifecycles,
     };
   },
   methods: {

--- a/examples/main-vue/src/views/Vue3.vue
+++ b/examples/main-vue/src/views/Vue3.vue
@@ -1,55 +1,20 @@
 <template>
   <!--保活模式，name相同则复用一个子应用实例，改变url无效，必须采用通信的方式告知路由变化 -->
-  <WujieVue
-    width="100%"
-    height="100%"
-    name="vue3"
-    :url="vue3Url"
-    :sync="true"
-    :fetch="fetch"
-    :alive="true"
-    :props="props"
-    :attrs="attrs"
-    :degrade="degrade"
-    :beforeLoad="lifecycles.beforeLoad"
-    :beforeMount="lifecycles.beforeMount"
-    :afterMount="lifecycles.afterMount"
-    :beforeUnmount="lifecycles.beforeUnmount"
-    :afterUnmount="lifecycles.afterUnmount"
-    :activated="lifecycles.activated"
-    :deactivated="lifecycles.deactivated"
-    :loadError="lifecycles.loadError"
-    :plugins="[{ cssExcludes: ['https://stackpath.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css'] }]"
-  ></WujieVue>
+  <WujieVue width="100%" height="100%" name="vue3" :url="vue3Url" :sync="true"></WujieVue>
 </template>
 
 <script>
 import hostMap from "../hostMap";
-import fetch from "../fetch";
-import lifecycles from "../lifecycle";
 import wujieVue from "wujie-vue2";
 export default {
   data() {
     return {
       vue3Url: hostMap("//localhost:7300/"),
-      props: { jump: this.jump },
-      // 修正iframe的url，防止github pages csp报错
-      attrs: process.env.NODE_ENV === "production" ? { src: hostMap("//localhost:7300/") } : {},
-      lifecycles,
-      // 引入了的第三方样式不需要添加credentials
-      fetch: (url, options) =>
-        url.includes(hostMap("//localhost:7300/")) ? fetch(url, options) : window.fetch(url, options),
-      degrade: window.localStorage.getItem("degrade") === "true",
     };
   },
   mounted() {
     // 告诉子应用要跳转哪个路由
     this.$route.params.path && wujieVue.bus.$emit("vue3-router-change", `/${this.$route.params.path}`);
-  },
-  methods: {
-    jump(name) {
-      this.$router.push({ name });
-    },
   },
 };
 </script>

--- a/packages/wujie-core/package.json
+++ b/packages/wujie-core/package.json
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "lib": "webpack build --config webpack.config.js",
-    "esm": "cross-env BABEL_ENV=esm babel ./src --out-dir ./esm --extensions .ts --source-maps",
+    "esm": "cross-env BABEL_ENV=esm babel ./src --out-dir ./esm --extensions .ts --source-maps && tsc --emitDeclarationOnly",
     "prepack": "bash build.sh",
     "start": "cross-env BABEL_ENV=esm babel ./src --out-dir ./esm --extensions .ts --source-maps inline --watch",
     "lint": "eslint --ext .ts ./src  --fix && git add .",

--- a/packages/wujie-core/src/common.ts
+++ b/packages/wujie-core/src/common.ts
@@ -1,20 +1,39 @@
 import Wujie from "./sandbox";
+import { cacheOptions } from "./index";
+export interface SandboxCache {
+  wujie?: Wujie;
+  options?: cacheOptions;
+}
 
-// 全部无界实例存储map
-export const idToSandboxMap = window.__POWERED_BY_WUJIE__
+// 全部无界实例和配置存储map
+export const idToSandboxCacheMap = window.__POWERED_BY_WUJIE__
   ? window.__WUJIE.inject.idToSandboxMap
-  : new Map<String, Wujie>();
+  : new Map<String, SandboxCache>();
 
-export function getSandboxById(id: String): Wujie | null {
-  return idToSandboxMap.get(id) || null;
+export function getWujieById(id: String): Wujie | null {
+  return idToSandboxCacheMap.get(id)?.wujie || null;
 }
 
-export function addSandboxIdMap(id: string, sandbox: Wujie) {
-  idToSandboxMap.set(id, sandbox);
+export function getOptionsById(id: String): cacheOptions | null {
+  return idToSandboxCacheMap.get(id)?.options || null;
 }
 
-export function deleteSandboxIdMap(id: string) {
-  idToSandboxMap.delete(id);
+export function addSandboxCacheWithWujie(id: string, sandbox: Wujie): void {
+  const wujieCache = idToSandboxCacheMap.get(id);
+  if (wujieCache) idToSandboxCacheMap.set(id, { ...wujieCache, wujie: sandbox });
+  else idToSandboxCacheMap.set(id, { wujie: sandbox });
+}
+
+export function deleteWujieById(id: string) {
+  const wujieCache = idToSandboxCacheMap.get(id);
+  if (wujieCache?.options) idToSandboxCacheMap.set(id, { options: wujieCache.options });
+  idToSandboxCacheMap.delete(id);
+}
+
+export function addSandboxCacheWithOptions(id: string, options: cacheOptions): void {
+  const wujieCache = idToSandboxCacheMap.get(id);
+  if (wujieCache) idToSandboxCacheMap.set(id, { ...wujieCache, options });
+  else idToSandboxCacheMap.set(id, { options });
 }
 
 // 分类document上需要处理的属性，不同类型会进入不同的处理逻辑

--- a/packages/wujie-core/src/effect.ts
+++ b/packages/wujie-core/src/effect.ts
@@ -1,6 +1,6 @@
 import { getExternalStyleSheets, getExternalScripts } from "./entry";
 import {
-  getSandboxById,
+  getWujieById,
   rawAppendChild,
   rawHeadInsertBefore,
   rawBodyInsertBefore,
@@ -134,7 +134,7 @@ function rewriteAppendOrInsertChild(opts: {
   ) {
     let element = newChild as any;
     const { rawDOMAppendOrInsertBefore, wujieId } = opts;
-    const sandbox = getSandboxById(wujieId);
+    const sandbox = getWujieById(wujieId);
 
     if (!isHijackingTag(element.tagName) || !wujieId) {
       return rawDOMAppendOrInsertBefore.call(this, element, refChild) as T;

--- a/packages/wujie-core/src/sandbox.ts
+++ b/packages/wujie-core/src/sandbox.ts
@@ -20,9 +20,10 @@ import { ScriptResultList } from "./entry";
 import { getPlugins, getJsBeforeLoaders, getJsAfterLoaders } from "./plugin";
 import { removeEventListener } from "./effect";
 import {
-  idToSandboxMap,
-  addSandboxIdMap,
-  deleteSandboxIdMap,
+  SandboxCache,
+  idToSandboxCacheMap,
+  addSandboxCacheWithWujie,
+  deleteWujieById,
   rawElementAppendChild,
   rawDocumentQuerySelector,
 } from "./common";
@@ -119,7 +120,7 @@ export default class Wujie {
 
   /** 子应用嵌套场景，父应用传递给子应用的数据 */
   public inject: {
-    idToSandboxMap: Map<String, Wujie>;
+    idToSandboxMap: Map<String, SandboxCache>;
     appEventObjMap: Map<String, EventObj>;
     mainHostPath: string;
   };
@@ -394,7 +395,7 @@ export default class Wujie {
     ).forEach((iframe) => {
       if (iframe.name === this.id) iframe.parentNode.removeChild(iframe);
     });
-    deleteSandboxIdMap(this.id);
+    deleteWujieById(this.id);
   }
 
   /** 当子应用再次激活后，只运行mount函数，样式需要重新恢复 */
@@ -448,7 +449,7 @@ export default class Wujie {
     if (window.__POWERED_BY_WUJIE__) this.inject = window.__WUJIE.inject;
     else {
       this.inject = {
-        idToSandboxMap,
+        idToSandboxMap: idToSandboxCacheMap,
         appEventObjMap,
         mainHostPath: window.location.protocol + "//" + window.location.host,
       };
@@ -489,6 +490,6 @@ export default class Wujie {
     }
     this.provide.location = this.proxyLocation;
 
-    addSandboxIdMap(this.id, this);
+    addSandboxCacheWithWujie(this.id, this);
   }
 }

--- a/packages/wujie-core/src/shadow.ts
+++ b/packages/wujie-core/src/shadow.ts
@@ -1,5 +1,5 @@
 import { WUJIE_DATA_ID, WUJIE_IFRAME_CLASS, WUJIE_SHADE_STYLE } from "./constant";
-import { getSandboxById, rawElementAppendChild, rawElementRemoveChild, relativeElementTagAttrMap } from "./common";
+import { getWujieById, rawElementAppendChild, rawElementRemoveChild, relativeElementTagAttrMap } from "./common";
 import { getExternalStyleSheets } from "./entry";
 import Wujie from "./sandbox";
 import { patchElementEffect } from "./iframe";
@@ -25,13 +25,13 @@ class WujieApp extends HTMLElement {
   connectedCallback(): void {
     if (this.shadowRoot) return;
     const shadowRoot = this.attachShadow({ mode: "open" });
-    const sandbox = getSandboxById(this.getAttribute(WUJIE_DATA_ID));
+    const sandbox = getWujieById(this.getAttribute(WUJIE_DATA_ID));
     patchElementEffect(shadowRoot, sandbox.iframe.contentWindow);
     sandbox.shadowRoot = shadowRoot;
   }
 
   disconnectedCallback(): void {
-    const sandbox = getSandboxById(this.getAttribute(WUJIE_DATA_ID));
+    const sandbox = getWujieById(this.getAttribute(WUJIE_DATA_ID));
     sandbox.unmount();
   }
 }

--- a/packages/wujie-core/src/sync.ts
+++ b/packages/wujie-core/src/sync.ts
@@ -1,7 +1,7 @@
 import { anchorElementGenerator, getAnchorElementQueryMap, getSyncUrl, appRouteParse, getDegradeIframe } from "./utils";
 import { renderIframeReplaceApp, patchEventTimeStamp } from "./iframe";
 import { renderElementToContainer, createIframeContainer, clearChild } from "./shadow";
-import { getSandboxById, rawDocumentQuerySelector } from "./common";
+import { getWujieById, rawDocumentQuerySelector } from "./common";
 
 /**
  * 同步子应用路由到主应用路由
@@ -66,7 +66,7 @@ export function clearInactiveAppUrl(): void {
   let winUrlElement = anchorElementGenerator(window.location.href);
   const queryMap = getAnchorElementQueryMap(winUrlElement);
   Object.keys(queryMap).forEach((id) => {
-    const sandbox = getSandboxById(id);
+    const sandbox = getWujieById(id);
     if (!sandbox) return;
     // 子应用执行过并且已经卸载才需要清除
     const clearFlag = sandbox.degrade
@@ -114,7 +114,7 @@ export function processAppForHrefJump(): void {
     const queryMap = getAnchorElementQueryMap(winUrlElement);
     winUrlElement = null;
     Object.keys(queryMap)
-      .map((id) => getSandboxById(id))
+      .map((id) => getWujieById(id))
       .filter((sandbox) => sandbox)
       .forEach((sandbox) => {
         const url = queryMap[sandbox.id];

--- a/packages/wujie-core/src/utils.ts
+++ b/packages/wujie-core/src/utils.ts
@@ -1,5 +1,5 @@
 import { WUJIE_TIPS_NO_URL, WUJIE_DATA_ID } from "./constant";
-import { plugin } from "./index";
+import { plugin, cacheOptions } from "./index";
 
 export function toArray<T>(array: T | T[]): T[] {
   return Array.isArray(array) ? array : [array];
@@ -274,4 +274,36 @@ export function getExcludes(
 // 判断 url 是否被排查
 export function isExcludeUrl(url: string, excludes: plugin["jsExcludes"] | plugin["cssExcludes"]): boolean {
   return excludes.some((excludeUrl) => (typeof excludeUrl === "string" ? url === excludeUrl : excludeUrl.test(url)));
+}
+
+// 合并缓存
+export function mergeOptions(options: cacheOptions, cacheOptions: cacheOptions) {
+  return {
+    name: options.name,
+    el: options.el || cacheOptions?.el,
+    url: options.url || cacheOptions?.url,
+    exec: options.exec !== undefined ? options.exec : cacheOptions?.exec,
+    replace: options.replace || cacheOptions?.replace,
+    fetch: options.fetch || cacheOptions?.fetch,
+    props: options.props || cacheOptions?.props,
+    sync: options.sync !== undefined ? options.sync : cacheOptions?.sync,
+    prefix: options.prefix || cacheOptions?.prefix,
+    // 默认 {}
+    attrs: options.attrs !== undefined ? options.attrs : cacheOptions?.attrs || {},
+    // 默认 true
+    fiber: options.fiber !== undefined ? options.fiber : cacheOptions?.fiber !== undefined ? cacheOptions?.fiber : true,
+    alive: options.alive !== undefined ? options.alive : cacheOptions?.alive,
+    degrade: options.degrade !== undefined ? options.degrade : cacheOptions?.degrade,
+    plugins: options.plugins || cacheOptions?.plugins,
+    lifecycles: {
+      beforeLoad: options.beforeLoad || cacheOptions?.beforeLoad,
+      beforeMount: options.beforeMount || cacheOptions?.beforeMount,
+      afterMount: options.afterMount || cacheOptions?.afterMount,
+      beforeUnmount: options.beforeUnmount || cacheOptions?.beforeUnmount,
+      afterUnmount: options.afterUnmount || cacheOptions?.afterUnmount,
+      activated: options.activated || cacheOptions?.activated,
+      deactivated: options.deactivated || cacheOptions?.deactivated,
+      loadError: options.loadError || cacheOptions?.loadError,
+    },
+  };
 }

--- a/packages/wujie-doc/docs/.vuepress/config.js
+++ b/packages/wujie-doc/docs/.vuepress/config.js
@@ -41,6 +41,7 @@ module.exports = {
           sidebarDepth: 2,
           children: [
             'bus.md',
+            'createApp.md',
             'startApp.md',
             'preloadApp.md',
             'destroyApp.md'

--- a/packages/wujie-doc/docs/README.md
+++ b/packages/wujie-doc/docs/README.md
@@ -14,11 +14,13 @@ footer: Copyright © 2021-present yiludege
 ---
 
 ```javascript
-import { bus, preloadApp, startApp, destroyAPP } from "wujie";
+import { bus, createApp, preloadApp, startApp, destroyAPP } from "wujie";
 
-preloadApp({ name: "唯一id", url: "子应用路径", exec: true });
+createApp({ name: "唯一id", url: "子应用路径", exec: true, el: "容器", sync: true });
 
-startApp({ name: "唯一id", url: "子应用路径", el: "容器", sync: true });
+preloadApp({ name: "唯一id" });
+
+startApp({ name: "唯一id" });
 
 bus.$on("事件名字", function(){});
 

--- a/packages/wujie-doc/docs/api/createApp.md
+++ b/packages/wujie-doc/docs/api/createApp.md
@@ -1,0 +1,55 @@
+# createApp
+
+- **类型：** `Function`
+
+- **参数：** `cacheOptions`
+
+- **返回值：**`void`
+
+```typescript
+type lifecycle = (appWindow: Window) => any;
+type loadErrorHandler = (url: string, e: Error) => any;
+
+type cacheOptions  {
+   /** 唯一性用户必须保证 */
+  name: string;
+  /** 需要渲染的url */
+  url: string;
+  /** 预执行 */
+  exec?: boolean;
+  /** 渲染的容器 */
+  el?: HTMLElement | string;
+  /** 路由同步开关 */
+  sync?: boolean;
+  /** 子应用短路径替换，路由同步时生效 */
+  prefix?: { [key: string]: string };
+  /** 代码替换钩子 */
+  replace?: (code: string) => string;
+  /** 自定义fetch */
+  fetch?: (input: RequestInfo, init?: RequestInit) => Promise<Response>;
+  /** 注入给子应用的属性 */
+  props?: { [key: string]: any };
+  /** 自定义iframe属性 */
+  attrs?: { [key: string]: any };
+  /** 子应用采用fiber模式执行 */
+  fiber?: boolean;
+  /** 子应用保活，state不会丢失 */
+  alive?: boolean;
+  /** 子应用采用降级iframe方案 */
+  degrade?: boolean;
+  /** 子应用插件 */
+  plugins?: Array<plugin>;
+  /** 子应用生命周期 */
+  beforeLoad?: lifecycle;
+  beforeMount?: lifecycle;
+  afterMount?: lifecycle;
+  beforeUnmount?: lifecycle;
+  afterUnmount?: lifecycle;
+  activated?: lifecycle;
+  deactivated?: lifecycle;
+  loadError?: loadErrorHandler;
+};
+```
+
+- **详情：** `createApp`创建子应用，主要作用是设置子应用默认属性，[startApp](/api/startApp.html)、[preloadApp](/api/preloadApp.html) 会从这里获取子应用默认属性，如果有相同的属性则会直接覆盖
+

--- a/packages/wujie-doc/docs/guide/start.md
+++ b/packages/wujie-doc/docs/guide/start.md
@@ -8,23 +8,29 @@ collapsable: false
 ### 引入
 
 ```javascript
-import { bus, preloadApp, startApp, destroyApp } from "wujie";
+import { bus, createApp, preloadApp, startApp, destroyApp } from "wujie";
 ```
 
 ::: tip 提示
 如果主应用是`vue`框架可直接使用 [wujie-vue](/pack/)，`react`框架可直接使用 [wujie-react](/pack/react.html)
 :::
 
+### 创建主应用
+
+```javascript
+createApp({{ name: "唯一id", url: "子应用地址", exec: true, el: "容器", sync: true }})
+```
+
 ### 预加载
 
 ```javascript
-preloadApp({ name: "唯一id", url: "子应用地址", exec: true });
+preloadApp({ name: "唯一id"});
 ```
 
 ### 启动子应用
 
 ```javascript
-startApp({ name: "唯一id", url: "子应用地址", el: "容器", sync: true }
+startApp({ name: "唯一id" });
 ```
 
 ## 子应用改造

--- a/packages/wujie-doc/docs/pack/README.md
+++ b/packages/wujie-doc/docs/pack/README.md
@@ -23,7 +23,7 @@ import WujieVue from "wujie-vue2";
 // vue3
 import WujieVue from "wujie-vue3";
 
-const { bus, preloadApp, destroyApp } = WujieVue;
+const { bus, createApp, preloadApp, destroyApp } = WujieVue;
 
 Vue.use(WujieVue);
 ```
@@ -52,6 +52,10 @@ Vue.use(WujieVue);
 ### bus
 
 [同 API](/api/bus.html)
+
+### createApp
+
+[同 API](/api/createApp.html)
 
 ### preloadApp
 
@@ -160,6 +164,7 @@ const wujieVueOptions = {
 
 const WujieVue = vue3Flag ? defineComponent(wujieVueOptions) : Vue.extend(wujieVueOptions);
 
+WujieVue.createApp = createApp;
 WujieVue.preloadApp = preloadApp;
 WujieVue.bus = bus;
 WujieVue.destroyApp = destroyApp;

--- a/packages/wujie-doc/docs/pack/react.md
+++ b/packages/wujie-doc/docs/pack/react.md
@@ -16,7 +16,7 @@ npm i wujie-react -S
 ```javascript
 import WujieReact from "wujie-react";
 
-const { bus, preloadApp, destroyApp } = WujieReact;
+const { bus, createApp, preloadApp, destroyApp } = WujieReact;
 ```
 
 ## 使用
@@ -42,6 +42,10 @@ const { bus, preloadApp, destroyApp } = WujieReact;
 
 [同 API](/api/bus.html)
 
+### createApp
+
+[同 API](/api/createApp.html)
+
 ### preloadApp
 
 [同 API](/api/preloadApp.html)
@@ -49,42 +53,6 @@ const { bus, preloadApp, destroyApp } = WujieReact;
 ### destroyApp
 
 [同 API](/api/destroyapp.html)
-
-## 常见问题
-
-#### 1、编译报错
-
-编译时报错：
-
-```
-ERROR in ./node_modules/wujie-react/esm/index.js 6:19
-Module parse failed: Unexpected token (6:19)
-You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
-|
-| export default class WujieReact extends React.PureComponent {
->   static propTypes = {
-|     height: PropTypes.string,
-|     width: PropTypes.string,
-```
-
-**原因**：wujie-react 编译有 esm 包和 lib 包且，默认采用 esm 包，esm 包没有进行 babel 处理，在 webpack 编译中导致报错。
-
-**解决**：
-
-
-方法 1：采用 lib 包
-
-```javascript
-import WujieReact from 'wujie-react/lib/index';
-```
-
-方法 2：webpack babel-loader 编译一下 wujie-react 和 wujie
-```javascript
-{
-  // babel-loader的 exclude 参数，排除掉 wujie-react 和 wujie
-  exclude: /node_modules\/(?!(wujie(-react)?)\/).*/,
-}
-```
 
 ## 原理
 
@@ -118,6 +86,7 @@ export default class WujieReact extends React.PureComponent {
     loadError: PropTypes.func,
   };
   static bus = bus;
+  static createApp = createApp;
   static preloadApp = preloadApp;
   static destroyApp = destroyApp;
 

--- a/packages/wujie-react/index.d.ts
+++ b/packages/wujie-react/index.d.ts
@@ -1,4 +1,4 @@
-import { bus, preloadApp, destroyApp } from "wujie";
+import { bus, preloadApp, destroyApp, createApp } from "wujie";
 import PropTypes from "prop-types";
 import React from "react";
 
@@ -27,6 +27,7 @@ export default class WujieReact extends React.PureComponent {
     loadError: typeof PropTypes.func,
   };
   static bus: typeof bus;
+  static createApp: typeof createApp;
   static preloadApp: typeof preloadApp;
   static destroyApp: typeof destroyApp;
 }

--- a/packages/wujie-react/index.js
+++ b/packages/wujie-react/index.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { bus, preloadApp, startApp, destroyApp } from "wujie";
+import { bus, preloadApp, startApp, destroyApp, createApp } from "wujie";
 
 export default class WujieReact extends React.PureComponent {
   static propTypes = {
@@ -28,6 +28,7 @@ export default class WujieReact extends React.PureComponent {
     loadError: PropTypes.func,
   };
   static bus = bus;
+  static createApp = createApp;
   static preloadApp = preloadApp;
   static destroyApp = destroyApp;
 

--- a/packages/wujie-vue2/index.d.ts
+++ b/packages/wujie-vue2/index.d.ts
@@ -1,8 +1,9 @@
 import Vue from "vue";
-import { bus, preloadApp, destroyApp } from "wujie";
+import { bus, preloadApp, destroyApp, createApp } from "wujie";
 
 declare const WujieVue: {
   bus: typeof bus;
+  createApp: typeof createApp;
   preloadApp: typeof preloadApp;
   destroyApp: typeof destroyApp;
   install: (Vue: Vue) => void;

--- a/packages/wujie-vue2/index.js
+++ b/packages/wujie-vue2/index.js
@@ -1,5 +1,5 @@
 import Vue from "vue";
-import { bus, preloadApp, startApp, destroyApp } from "wujie";
+import { bus, preloadApp, startApp, destroyApp, createApp } from "wujie";
 
 const wujieVueOptions = {
   name: "WujieVue",
@@ -8,15 +8,15 @@ const wujieVueOptions = {
     height: { type: String, default: "" },
     name: { type: String, default: "" },
     url: { type: String, default: "" },
-    sync: { type: Boolean, default: false },
+    sync: { type: Boolean, default: undefined },
     prefix: { type: Object, default: undefined },
-    alive: { type: Boolean, default: false },
+    alive: { type: Boolean, default: undefined },
     props: { type: Object, default: undefined },
     attrs: {type: Object, default: undefined},
     replace: { type: Function, default: undefined },
     fetch: { type: Function, default: undefined },
-    fiber: { type: Boolean, default: true },
-    degrade: { type: Boolean, default: false },
+    fiber: { type: Boolean, default: undefined },
+    degrade: { type: Boolean, default: undefined },
     plugins: { type: Array, default: null },
     beforeLoad: { type: Function, default: null },
     beforeMount: { type: Function, default: null },
@@ -93,6 +93,7 @@ const wujieVueOptions = {
 
 const WujieVue = Vue.extend(wujieVueOptions);
 
+WujieVue.createApp = createApp;
 WujieVue.preloadApp = preloadApp;
 WujieVue.bus = bus;
 WujieVue.destroyApp = destroyApp;

--- a/packages/wujie-vue3/index.d.ts
+++ b/packages/wujie-vue3/index.d.ts
@@ -1,8 +1,9 @@
-import { bus, preloadApp, destroyApp } from "wujie";
+import { bus, preloadApp, destroyApp, createApp } from "wujie";
 import { App } from "vue";
 
 declare const WujieVue: {
   bus: typeof bus;
+  createApp: typeof createApp;
   preloadApp: typeof preloadApp;
   destroyApp: typeof destroyApp;
   install: (app: App) => any;

--- a/packages/wujie-vue3/index.js
+++ b/packages/wujie-vue3/index.js
@@ -1,4 +1,4 @@
-import { bus, preloadApp, startApp, destroyApp } from "wujie";
+import { bus, preloadApp, startApp, destroyApp, createApp } from "wujie";
 import { h, defineComponent } from "vue";
 
 const wujieVueOptions = {
@@ -8,15 +8,15 @@ const wujieVueOptions = {
     height: { type: String, default: "" },
     name: { type: String, default: "" },
     url: { type: String, default: "" },
-    sync: { type: Boolean, default: false },
+    sync: { type: Boolean, default: undefined },
     prefix: { type: Object, default: undefined },
-    alive: { type: Boolean, default: false },
+    alive: { type: Boolean, default: undefined },
     props: { type: Object, default: undefined },
     attrs: {type: Object, default: undefined},
     replace: { type: Function, default: undefined },
     fetch: { type: Function, default: undefined },
-    fiber: { type: Boolean, default: true },
-    degrade: { type: Boolean, default: false },
+    fiber: { type: Boolean, default: undefined },
+    degrade: { type: Boolean, default: undefined },
     plugins: { type: Array, default: null },
     beforeLoad: { type: Function, default: null },
     beforeMount: { type: Function, default: null },
@@ -93,6 +93,7 @@ const wujieVueOptions = {
 
 const WujieVue = defineComponent(wujieVueOptions);
 
+WujieVue.createApp = createApp;
 WujieVue.preloadApp = preloadApp;
 WujieVue.bus = bus;
 WujieVue.destroyApp = destroyApp;


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [x] 文档更改
- [x] `npm run test`通过

##### 详细描述

- 特性
preloadApp 和 startApp 有大量的相同配置项，这样配置项就需要写两次，而且有些配置还需要保持一致，为了最大化的减少冗余和出错，提供一个全局配置api createApp，preloadApp 和 startApp 都从这个配置项读取默认配置

- 关联issue
#59 
