### PR TITLE
fix: 修复子应用加载页面生命周期无法触发

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,8 +147,5 @@ import WujieReact from "wujie-react";
 
 ```bash
 npm i                   // 安装包依赖
-npx husky install       // Enable Git hooks
-npm i -g lerna          // 安装 lerna
-lerna bootstrap         // 安装所有子应用包依赖
-npm run start           // 启动子应用
+npm run start           // 启动所有应用
 ```

--- a/examples/vue2/src/main.js
+++ b/examples/vue2/src/main.js
@@ -12,6 +12,7 @@ import AButton from "ant-design-vue/es/button";
 import ASelect from "ant-design-vue/es/select";
 import AModal from "ant-design-vue/es/modal";
 import APopover from "ant-design-vue/es/popover";
+import "./pageLifeTest";
 import "element-ui/lib/theme-chalk/base.css";
 import "element-ui/lib/theme-chalk/tag.css";
 import "element-ui/lib/theme-chalk/button.css";

--- a/examples/vue2/src/pageLifeTest.js
+++ b/examples/vue2/src/pageLifeTest.js
@@ -1,0 +1,22 @@
+// 测试页面加载生命周期，集成测试使用
+document.addEventListener("DOMContentLoaded", () => {
+  console.log("vue2 document DOMContentLoaded trigger");
+});
+
+window.addEventListener("DOMContentLoaded", () => {
+  console.log("vue2 window DOMContentLoaded trigger");
+});
+
+document.onreadystatechange = function () {
+  console.log("vue2 document onreadystatechange trigger");
+};
+
+document.addEventListener("readystatechange", () => {
+  console.log("vue2 document readystatechange trigger");
+});
+
+window.onload = () => console.log("vue2 window onload trigger");
+
+window.addEventListener("load", () => {
+  console.log("vue2 window load trigger");
+});

--- a/packages/wujie-core/__test__/integration/pageEvent.test.ts
+++ b/packages/wujie-core/__test__/integration/pageEvent.test.ts
@@ -1,0 +1,60 @@
+// 子应用页面事件
+import { awaitConsoleLogMessage } from "./utils";
+import { reactMainAppInfoMap, vueMainAppInfoMap } from "./common";
+
+const pageLiftEventConsoleLogList = [
+  "vue2 document DOMContentLoaded trigger",
+  "vue2 window DOMContentLoaded trigger",
+  "vue2 document onreadystatechange trigger",
+  "vue2 document readystatechange trigger",
+  "vue2 window onload trigger",
+  "vue2 window load trigger",
+];
+
+describe("main react pageEvent", () => {
+  beforeAll(async () => {
+    await page.evaluateOnNewDocument(() => {
+      // 关闭预加载
+      localStorage.clear();
+      localStorage.setItem("preload", "false");
+      localStorage.setItem("degrade", "false");
+    });
+    await page.goto("http://localhost:7700/");
+  });
+
+  const vue2 = reactMainAppInfoMap.vue2;
+  it(`${vue2.name} pageEvent trigger`, async () => {
+    // vue2
+    const vue2MountedPromise = awaitConsoleLogMessage(page, vue2.mountedMessage);
+    await page.click(vue2.linkSelector);
+    const pageLiftEventConsoleLogListPromise = pageLiftEventConsoleLogList.map((message) =>
+      awaitConsoleLogMessage(page, message)
+    );
+    await vue2MountedPromise;
+    await Promise.all(pageLiftEventConsoleLogListPromise);
+  });
+});
+
+describe("main vue pageEvent", () => {
+  beforeAll(async () => {
+    await page.evaluateOnNewDocument(() => {
+      // 关闭预加载
+      localStorage.clear();
+      localStorage.setItem("preload", "false");
+      localStorage.setItem("degrade", "false");
+    });
+    await page.goto("http://localhost:8000/");
+  });
+
+  const vue2 = vueMainAppInfoMap.vue2;
+  it(`${vue2.name} pageEvent trigger`, async () => {
+    // vue2
+    const vue2MountedPromise = awaitConsoleLogMessage(page, vue2.mountedMessage);
+    await page.click(vue2.linkSelector);
+    const pageLiftEventConsoleLogListPromise = pageLiftEventConsoleLogList.map((message) =>
+      awaitConsoleLogMessage(page, message)
+    );
+    await vue2MountedPromise;
+    await Promise.all(pageLiftEventConsoleLogListPromise);
+  });
+});

--- a/packages/wujie-core/src/common.ts
+++ b/packages/wujie-core/src/common.ts
@@ -119,7 +119,6 @@ export const documentProxyProperties = {
 
   // 需要从主应用document中获取的事件
   documentEvents: [
-    "onreadystatechange",
     "onpointerlockchange",
     "onpointerlockerror",
     "onbeforecopy",
@@ -138,12 +137,13 @@ export const documentProxyProperties = {
   ownerProperties: ["head", "body"],
 };
 
+// 需要挂载到子应用iframe document上的事件
+export const appDocumentAddEventListenerEvents = ["DOMContentLoaded", "readystatechange"];
+export const appDocumentOnEvents = ["onreadystatechange"];
 // 需要挂载到主应用document上的事件
-export const documentAddEventListenerEvents = [
-  "DOMContentLoaded",
+export const mainDocumentAddEventListenerEvents = [
   "fullscreenchange",
   "fullscreenerror",
-  "readystatechange",
   "scroll",
   "selectionchange",
   "visibilitychange",
@@ -151,9 +151,20 @@ export const documentAddEventListenerEvents = [
 ];
 
 // 需要同时挂载到主应用document和shadow上的事件（互斥）
-export const rootAddEventListenerEvents = ["gotpointercapture", "lostpointercapture"];
+export const mainAndAppAddEventListenerEvents = ["gotpointercapture", "lostpointercapture"];
 
-export const iframeAddEventListenerEvents = ["hashchange", "popstate"];
+// 子应用window监听需要挂载到iframe沙箱上的事件
+export const appWindowAddEventListenerEvents = [
+  "hashchange",
+  "popstate",
+  "DOMContentLoaded",
+  "load",
+  "beforeunload",
+  "unload",
+];
+
+// 子应用window.onXXX需要挂载到iframe沙箱上的事件
+export const appWindowOnEvent = ["onload", "onbeforeunload", "onunload"];
 
 // 相对路径问题元素的tag和attr的map
 export const relativeElementTagAttrMap = {

--- a/packages/wujie-core/src/utils.ts
+++ b/packages/wujie-core/src/utils.ts
@@ -307,3 +307,17 @@ export function mergeOptions(options: cacheOptions, cacheOptions: cacheOptions) 
     },
   };
 }
+
+/**
+ * 事件触发器
+ */
+export function eventTrigger(el: HTMLElement | Window | Document, eventName: string, detail?: any) {
+  let event;
+  if (typeof window.CustomEvent === "function") {
+    event = new CustomEvent(eventName, { detail });
+  } else {
+    event = document.createEvent("CustomEvent");
+    event.initCustomEvent(eventName, true, false, detail);
+  }
+  el.dispatchEvent(event);
+}


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [x] 文档更改
- [x] 测试用例添加
- [x] `npm run test`通过

##### 详细描述

- 特性
 1、修复子应用在加载的过程中，DOMContentLoaded事件、load事件、readystatechange事件无法触发的问题
 2、修改README
- 关联issue
#49 #43 
