### PR TITLE
fix: 修复集成测试失败

### DIFF
--- a/packages/wujie-core/__test__/integration/font.test.ts
+++ b/packages/wujie-core/__test__/integration/font.test.ts
@@ -21,7 +21,7 @@ describe("main react startApp", () => {
     await triggerClickByJsSelector(page, appInfo.fontNavSelector);
     await appInfoFontMountedPromise;
     // 等待字体加载
-    await page.waitForResponse((response) => response.url().includes("https://tdesign.gtimg.com/icon/0.1.1/fonts"));
+    await page.waitForResponse((response) => response.url().includes("https://tdesign.gtimg.com/icon/"));
     // 等待字体装载
     await new Promise((resolve) => setTimeout(resolve, 1000));
     // 检查字体是否生效
@@ -48,7 +48,7 @@ describe("main vue startApp", () => {
     await triggerClickByJsSelector(page, appInfo.fontNavSelector);
     await appInfoFontMountedPromise;
     // 等待字体加载
-    await page.waitForResponse((response) => response.url().includes("https://tdesign.gtimg.com/icon/0.1.1/fonts"));
+    await page.waitForResponse((response) => response.url().includes("https://tdesign.gtimg.com/icon/"));
     // 等待字体装载
     await new Promise((resolve) => setTimeout(resolve, 1000));
     // 检查字体是否生效

--- a/packages/wujie-core/src/effect.ts
+++ b/packages/wujie-core/src/effect.ts
@@ -72,18 +72,13 @@ function handleStylesheetElementPatch(stylesheetElement: HTMLStyleElement, sandb
 /**
  * 劫持处理样式元素的属性
  */
-
-type stylesheetElement = HTMLStyleElement & {
-  _hasPatch?: boolean // 判断新增的style标签是否被劫持
-}
-
 function patchStylesheetElement(
-  stylesheetElement: stylesheetElement,
+  stylesheetElement: HTMLStyleElement & { _hasPatch?: boolean },
   cssLoader: (code: string, url: string, base: string) => string,
   sandbox: Wujie,
   curUrl: string
 ) {
-  if( stylesheetElement._hasPatch ) return
+  if (stylesheetElement._hasPatch) return;
   const innerHTMLDesc = Object.getOwnPropertyDescriptor(Element.prototype, "innerHTML");
   const innerTextDesc = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "innerText");
   const textContentDesc = Object.getOwnPropertyDescriptor(Node.prototype, "textContent");
@@ -126,11 +121,7 @@ function patchStylesheetElement(
         } else return rawAppendChild(node);
       },
     },
-    _hasPatch: {
-      get: function () {
-        return true
-      }
-    }
+    _hasPatch: { get: () => true },
   });
 }
 

--- a/packages/wujie-core/src/sandbox.ts
+++ b/packages/wujie-core/src/sandbox.ts
@@ -300,7 +300,7 @@ export default class Wujie {
     const domContentLoadedTrigger = () => {
       eventTrigger(iframeWindow.document, "DOMContentLoaded");
       eventTrigger(iframeWindow, "DOMContentLoaded");
-      this.execQueue.shift()();
+      this.execQueue.shift()?.();
     };
     this.execQueue.push(this.fiber ? () => requestIdleCallback(domContentLoadedTrigger) : domContentLoadedTrigger);
 
@@ -317,7 +317,7 @@ export default class Wujie {
     const domLoadedTrigger = () => {
       eventTrigger(iframeWindow.document, "readystatechange");
       eventTrigger(iframeWindow, "load");
-      this.execQueue.shift()();
+      this.execQueue.shift()?.();
     };
     this.execQueue.push(this.fiber ? () => requestIdleCallback(domLoadedTrigger) : domLoadedTrigger);
     this.execQueue.shift()();


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [x] `npm run test`通过

##### 详细描述

- 特性
1、集成测试中 Tdesign icon 更新版本，导致测试用例失败
2、执行队列没有判空导致测试用例失败
3、refactor 一下代码
- 关联issue
#85 #80 