### PR TITLE
fix(plugin): fix cssLoader to exclude a data URL

### DIFF
--- a/packages/wujie-core/src/plugin.ts
+++ b/packages/wujie-core/src/plugin.ts
@@ -56,11 +56,11 @@ export function isMatchUrl(url: string, effectLoaders: plugin[effectLoadersType]
  */
 function cssRelativePathResolve(code: string, src: string, base: string) {
   const baseUrl = src ? getAbsolutePath(src, base) : base;
-  const urlReg = /(url\()([^)]*)(\))/g;
+  // https://developer.mozilla.org/en-US/docs/Web/CSS/url
+  const urlReg = /(url\((?!['"]?(?:data):)['"]?)([^'"\)]*)(['"]?\))/g;
   return code.replace(urlReg, (_m, pre, url, post) => {
-    const urlString = url.replace(/["']/g, "");
-    const absoluteUrl = getAbsolutePath(urlString, baseUrl);
-    return pre + "'" + absoluteUrl + "'" + post;
+    const absoluteUrl = getAbsolutePath(url, baseUrl);
+    return pre + absoluteUrl + post;
   });
 }
 


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [ ] 文档更改
- [ ] 测试用例添加
- [x] `npm run test`通过

##### 详细描述
https://github.com/Tencent/wujie/blob/master/packages/wujie-core/src/plugin.ts#L57
The default plugin contains a transform for css url(), which should only apply for url path, but not all other url() valid type such as: `url(data:image/png;base64,iRxVB0…);`

- The problem with the current implementation is that it replaces any ["'] in the data url, this shouldn't happen.
- This PR adds an exclude for url(data:) css in default css Loader
- This PR also refactor the regex to replace the url directly

