### PR TITLE
fix: preload options name shoule be the only required property 

### DIFF
--- a/docs/api/preloadApp.md
+++ b/docs/api/preloadApp.md
@@ -12,7 +12,7 @@ type preOptions  {
   /** 唯一性用户必须保证 */
   name: string;
   /** 需要渲染的url */
-  url: string;
+  url?: string;
   /** 注入给子应用的数据 */
   props?: { [key: string]: any };
   /** 自定义iframe属性 */

--- a/packages/wujie-core/src/index.ts
+++ b/packages/wujie-core/src/index.ts
@@ -103,9 +103,9 @@ type baseOptions = {
   loadError?: loadErrorHandler;
 };
 
-export type preOptions = baseOptions & {
-  /** 预执行 */
-  exec?: boolean;
+export type preOptions = Partial<baseOptions> & {
+  /** 唯一性用户必须保证 */
+  name: string;
 };
 
 export type startOptions = baseOptions & {


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [x] 文档更改
- [ ] 测试用例添加
- [x] `npm run test`通过

##### 详细描述

name should be the only required prop in preloadApp, url should be optional. In this function, it will get the option by name, and merge the argurment to the default argument. So url is not needed for preloadApp

- 特性
- 关联issue
