### PR TITLE
fix: 修复绝对路径对hash路由的影响

### DIFF
--- a/packages/wujie-core/src/utils.ts
+++ b/packages/wujie-core/src/utils.ts
@@ -164,7 +164,7 @@ export function fixElementCtrSrcOrHref(
   const rawElementSetAttribute = iframeWindow.Element.prototype.setAttribute;
   elementCtr.prototype.setAttribute = function (name: string, value: string): void {
     let targetValue = value;
-    if (name === attr) targetValue = getAbsolutePath(value, this.baseURI || "");
+    if (name === attr) targetValue = getAbsolutePath(value, this.baseURI || "", true);
     rawElementSetAttribute.call(this, name, targetValue);
   };
   // patch href get and set
@@ -177,7 +177,7 @@ export function fixElementCtrSrcOrHref(
       return get.call(this);
     },
     set: function (href) {
-      set.call(this, getAbsolutePath(href, this.baseURI));
+      set.call(this, getAbsolutePath(href, this.baseURI, true));
     },
   });
   // TODO: innerHTML的处理
@@ -188,10 +188,12 @@ export function getCurUrl(proxyLocation: Object): string {
   return location.protocol + "//" + location.host + location.pathname;
 }
 
-export function getAbsolutePath(url: string, base: string): string {
+export function getAbsolutePath(url: string, base: string, hash): string {
   try {
-    // 为空值或者hash值无需处理
-    if (url && !url.startsWith("#")) {
+    // 为空值无需处理
+    if (url) {
+      // 需要处理hash的场景
+      if (hash && url.startsWith("#")) return url;
       return new URL(url, base).href;
     } else return url;
   } catch {


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [ ] 文档更改
- [ ] 测试用例添加
- [x] `npm run test`通过

##### 详细描述

- 特性
如果是hash的场景就没有转化为绝对路径，在`<a>`元素锚点是正常的，但是对于hash路由还是需要转化成绝对路径
- 关联issue
#136 