### PR TITLE
fix: 修复react16 scroll合成事件无法触发问题

### DIFF
--- a/packages/wujie-core/src/common.ts
+++ b/packages/wujie-core/src/common.ts
@@ -144,7 +144,6 @@ export const appDocumentOnEvents = ["onreadystatechange"];
 export const mainDocumentAddEventListenerEvents = [
   "fullscreenchange",
   "fullscreenerror",
-  "scroll",
   "selectionchange",
   "visibilitychange",
   "wheel",


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [ ] 文档更改
- [ ] 测试用例添加
- [x] `npm run test`通过

##### 详细描述

- 特性
由于框架将document的scroll绑定到主应用的document上，导致react16的合成事件onscroll无法触发，去除这部分逻辑
- 关联issue
#143 