### PR TITLE
fix: 🐛 jsx syntax used in js file

### DIFF
--- a/docs/pack/react.md
+++ b/docs/pack/react.md
@@ -59,35 +59,12 @@ const { bus, setupApp, preloadApp, destroyApp } = WujieReact;
 ## 原理
 
 ```javascript
-import React from "react";
+import React, { createElement } from "react";
 import PropTypes from "prop-types";
-import { bus, setupApp ,preloadApp, startApp, destroyApp } from "wujie";
+import { bus, preloadApp, startApp, destroyApp, setupApp } from "wujie";
 
 export default class WujieReact extends React.PureComponent {
-  static propTypes = {
-    height: PropTypes.string,
-    width: PropTypes.string,
-    name: PropTypes.string,
-    loading: PropTypes.element;
-    url: PropTypes.string,
-    alive: PropTypes.bool,
-    fetch: PropTypes.func,
-    props: PropTypes.object,
-    replace: PropTypes.func,
-    sync: PropTypes.bool,
-    prefix: PropTypes.object,
-    fiber: PropTypes.bool,
-    degrade: PropTypes.bool,
-    plugins: PropTypes.array,
-    beforeLoad: PropTypes.func,
-    beforeMount: PropTypes.func,
-    afterMount: PropTypes.func,
-    beforeUnmount: PropTypes.func,
-    afterUnmount: PropTypes.func,
-    activated: PropTypes.func,
-    deactivated: PropTypes.func,
-    loadError: PropTypes.func,
-  };
+  static propTypes = propTypes;
   static bus = bus;
   static setupApp = setupApp;
   static preloadApp = preloadApp;
@@ -101,69 +78,62 @@ export default class WujieReact extends React.PureComponent {
 
   startAppQueue = Promise.resolve();
 
+  startApp = async () => {
+    try {
+      const props = this.props;
+      const { current: el } = this.state.myRef;
+      this.destroy = await startApp({
+        ...props,
+        el,
+      });
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
   execStartApp = () => {
-    const {
-      name,
-      url,
-      loading,
-      alive,
-      fetch,
-      props,
-      replace,
-      sync,
-      prefix,
-      fiber,
-      degrade,
-      plugins,
-      beforeLoad,
-      beforeMount,
-      afterMount,
-      beforeUnmount,
-      afterUnmount,
-      activated,
-      deactivated,
-      loadError,
-    } = this.props;
-    this.startAppQueue = this.startAppQueue.then(async () => {
-      try {
-        this.destroy = await startApp({
-          name,
-          url,
-          el: this.state.myRef.current,
-          loading,
-          alive,
-          fetch,
-          props,
-          replace,
-          sync,
-          prefix,
-          fiber,
-          degrade,
-          plugins,
-          beforeLoad,
-          beforeMount,
-          afterMount,
-          beforeUnmount,
-          afterUnmount,
-          activated,
-          deactivated,
-          loadError,
-        });
-      } catch (error) {
-        console.log(error);
-      }
-    });
+    this.startAppQueue = this.startAppQueue.then(this.startApp);
   };
 
   render() {
     this.execStartApp();
-    return React.createElement("div", {
+
+    const { width, height } = this.props;
+    const { myRef: ref } = this.state;
+    return createElement("div", {
       style: {
-        width: this.props.width,
-        height: this.props.height,
+        width,
+        height,
       },
-      ref: this.state.myRef,
+      ref,
     });
   }
 }
+
+const propTypes = {
+  height: PropTypes.string,
+  width: PropTypes.string,
+  name: PropTypes.string,
+  loading: PropTypes.element,
+  url: PropTypes.string,
+  alive: PropTypes.bool,
+  fetch: PropTypes.func,
+  props: PropTypes.object,
+  attrs: PropTypes.object,
+  replace: PropTypes.func,
+  sync: PropTypes.bool,
+  prefix: PropTypes.object,
+  fiber: PropTypes.bool,
+  degrade: PropTypes.bool,
+  plugins: PropTypes.array,
+  beforeLoad: PropTypes.func,
+  beforeMount: PropTypes.func,
+  afterMount: PropTypes.func,
+  beforeUnmount: PropTypes.func,
+  afterUnmount: PropTypes.func,
+  activated: PropTypes.func,
+  deactivated: PropTypes.func,
+  loadError: PropTypes.func,
+};
+
 ```

--- a/packages/wujie-react/index.js
+++ b/packages/wujie-react/index.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { createElement } from "react";
 import PropTypes from "prop-types";
 import { bus, preloadApp, startApp, destroyApp, setupApp } from "wujie";
 
@@ -28,7 +28,7 @@ export default class WujieReact extends React.PureComponent {
     } catch (error) {
       console.log(error);
     }
-  }
+  };
 
   execStartApp = () => {
     this.startAppQueue = this.startAppQueue.then(this.startApp);
@@ -39,32 +39,38 @@ export default class WujieReact extends React.PureComponent {
 
     const { width, height } = this.props;
     const { myRef: ref } = this.state;
-    return <div style={{ width, height }} ref={ref} />;
+    return createElement("div", {
+      style: {
+        width,
+        height,
+      },
+      ref,
+    });
   }
 }
 
 const propTypes = {
-    height: PropTypes.string,
-    width: PropTypes.string,
-    name: PropTypes.string,
-    loading: PropTypes.element,
-    url: PropTypes.string,
-    alive: PropTypes.bool,
-    fetch: PropTypes.func,
-    props: PropTypes.object,
-    attrs: PropTypes.object,
-    replace: PropTypes.func,
-    sync: PropTypes.bool,
-    prefix: PropTypes.object,
-    fiber: PropTypes.bool,
-    degrade: PropTypes.bool,
-    plugins: PropTypes.array,
-    beforeLoad: PropTypes.func,
-    beforeMount: PropTypes.func,
-    afterMount: PropTypes.func,
-    beforeUnmount: PropTypes.func,
-    afterUnmount: PropTypes.func,
-    activated: PropTypes.func,
-    deactivated: PropTypes.func,
-    loadError: PropTypes.func,
-  }
+  height: PropTypes.string,
+  width: PropTypes.string,
+  name: PropTypes.string,
+  loading: PropTypes.element,
+  url: PropTypes.string,
+  alive: PropTypes.bool,
+  fetch: PropTypes.func,
+  props: PropTypes.object,
+  attrs: PropTypes.object,
+  replace: PropTypes.func,
+  sync: PropTypes.bool,
+  prefix: PropTypes.object,
+  fiber: PropTypes.bool,
+  degrade: PropTypes.bool,
+  plugins: PropTypes.array,
+  beforeLoad: PropTypes.func,
+  beforeMount: PropTypes.func,
+  afterMount: PropTypes.func,
+  beforeUnmount: PropTypes.func,
+  afterUnmount: PropTypes.func,
+  activated: PropTypes.func,
+  deactivated: PropTypes.func,
+  loadError: PropTypes.func,
+};


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [x] 文档更改
- [ ] 测试用例添加
- [ ] `npm run test`通过

##### 详细描述
JSX syntax is used in a js file, change it from sugar to function calls.

**From:**
```js
return <div style={{ width, height }} ref={ref} />;
```
**To:**
```js
return createElement("div", {
      style: {
        width,
        height,
      },
      ref,
    });
```

- 特性
- 关联issue
