### PR TITLE
fix: 修复react hash 模式下异常

### DIFF
--- a/packages/wujie-core/src/proxy.ts
+++ b/packages/wujie-core/src/proxy.ts
@@ -162,6 +162,13 @@ export function proxyGenerator(
           warn(WUJIE_TIPS_RELOAD_DISABLED);
           return () => null;
         }
+        if (propKey === "replace") {
+          return new Proxy(location[propKey], {
+            apply(replace, _ctx, args) {
+              return replace.call(location, args[0]?.replace(appHostPath, mainHostPath));
+            },
+          });
+        }
         return getTargetValue(location, propKey);
       },
       set: function (_fakeLocation, propKey, value) {


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [ ] 文档更改
- [ ] 测试用例添加
- [x] `npm run test`通过

##### 详细描述

- 特性
window.location.href 、host 等都被代理到子应用的 href、host，导致 locaiton.replace 需要修改回来防止将 iframe 沙箱刷掉
- 关联issue
#151 
