### PR TITLE
fix: 修复preload 没有使用自定义fetch

### DIFF
--- a/packages/wujie-core/src/index.ts
+++ b/packages/wujie-core/src/index.ts
@@ -260,7 +260,8 @@ export function preloadApp(preOptions: preOptions): void {
     const cacheOptions = getOptionsById(preOptions.name);
     // 合并缓存配置
     const options = mergeOptions({ ...preOptions }, cacheOptions);
-    const { name, url, props, alive, replace, exec, attrs, fiber, degrade, plugins, lifecycles } = options;
+    const { name, url, props, alive, replace, fetch, exec, attrs, fiber, degrade, prefix, plugins, lifecycles } =
+      options;
 
     const sandbox = new WuJie({ name, url, attrs, fiber, degrade, plugins, lifecycles });
     if (sandbox.preload) return sandbox.preload;
@@ -272,7 +273,7 @@ export function preloadApp(preOptions: preOptions): void {
         loadError: sandbox.lifecycles.loadError,
       });
       const processedHtml = await processCssLoader(sandbox, template, getExternalStyleSheets);
-      await sandbox.active({ url, props, alive, template: processedHtml, fetch, replace });
+      await sandbox.active({ url, props, prefix, alive, template: processedHtml, fetch, replace });
       if (exec) {
         await sandbox.start(getExternalScripts);
       }


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [ ] 文档更改
- [ ] 测试用例添加
- [x] `npm run test`通过

##### 详细描述

- 特性
在开发setupApp的时候，preloadApp的自定义fetch没有添加上，导致预加载的自定义fetch出现问题
- 关联issue
#149 
