### PR TITLE
fix: 修复子应用切换导致样式重复的问题

### DIFF
--- a/packages/wujie-core/src/effect.ts
+++ b/packages/wujie-core/src/effect.ts
@@ -163,7 +163,10 @@ function rewriteAppendOrInsertChild(opts: {
     if (element.tagName) {
       switch (element.tagName?.toUpperCase()) {
         case "LINK": {
-          const { href } = element as HTMLLinkElement;
+          const { href, rel, type } = element as HTMLLinkElement;
+          const styleFlag = rel === "stylesheet" || type === "text/css" || href.endsWith(".css");
+          // 非 stylesheet 不做处理
+          if (!styleFlag) return rawDOMAppendOrInsertBefore.call(this, element, refChild);
           // 排除css
           if (href && !isMatchUrl(href, getEffectLoaders("cssExcludes", plugins))) {
             getExternalStyleSheets(

--- a/packages/wujie-core/src/shadow.ts
+++ b/packages/wujie-core/src/shadow.ts
@@ -103,7 +103,8 @@ async function processCssLoaderForTemplate(sandbox: Wujie, html: HTMLHtmlElement
         styleElement.setAttribute("type", "text/css");
         styleElement.appendChild(document.createTextNode(content ? cssLoader(content, src, curUrl) : content));
         const head = html.querySelector("head");
-        head?.insertBefore(styleElement, html.querySelector("head")?.firstChild);
+        const body = html.querySelector("body");
+        html.insertBefore(styleElement, head || body || html.firstChild);
       });
     }),
     Promise.all(


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [ ] 文档更改
- [ ] 测试用例添加
- [x] `npm run test`通过

##### 详细描述

- 特性
1、由于css-before-loader添加的样式放置到head导致样式被收集，切换后反复添加
2、link 标签只应该处理 stylesheet ，其他资源不应该处理，导致被样式被收集
- 关联issue
#161 
