### PR TITLE
fix: 修复子应用切换模板样式重复问题

### DIFF
--- a/packages/wujie-core/src/shadow.ts
+++ b/packages/wujie-core/src/shadow.ts
@@ -8,7 +8,13 @@ import {
   WUJIE_LOADING_STYLE,
   WUJIE_LOADING_SVG,
 } from "./constant";
-import { getWujieById, rawElementAppendChild, rawElementRemoveChild, relativeElementTagAttrMap } from "./common";
+import {
+  getWujieById,
+  rawAppendChild,
+  rawElementAppendChild,
+  rawElementRemoveChild,
+  relativeElementTagAttrMap,
+} from "./common";
 import { getExternalStyleSheets } from "./entry";
 import Wujie from "./sandbox";
 import { patchElementEffect } from "./iframe";
@@ -132,14 +138,14 @@ function replaceHeadAndBody(html: HTMLHtmlElement, head: HTMLHeadElement, body: 
   const bodyElement = html.querySelector("body");
   if (headElement) {
     while (headElement.firstChild) {
-      head.appendChild(headElement.firstChild.cloneNode(true));
+      rawAppendChild.call(head, headElement.firstChild.cloneNode(true));
       headElement.removeChild(headElement.firstChild);
     }
     headElement.parentNode.replaceChild(head, headElement);
   }
   if (bodyElement) {
     while (bodyElement.firstChild) {
-      body.appendChild(bodyElement.firstChild.cloneNode(true));
+      rawAppendChild.call(body, bodyElement.firstChild.cloneNode(true));
       bodyElement.removeChild(bodyElement.firstChild);
     }
     bodyElement.parentNode.replaceChild(body, bodyElement);


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [ ] 文档更改
- [ ] 测试用例添加
- [x] `npm run test`通过

##### 详细描述

- 特性
由于 head 和 body 元素在每次切换的时候都需要复用，防止被缓存。切换子应用时需要将 template 反复的插入到这两个元素中，而其 appendChild 和 insertBefore 已经被劫持过，导致 template 里面的样式被反复推入缓存样式表内

所以 template 反复的插入到这两个元素中采用的 appendChild 为原生而非劫持的方法
- 关联issue
- #161 
