### PR TITLE
fix: 修复defer脚本无法关闭fiber模式

### DIFF
--- a/packages/wujie-core/src/index.ts
+++ b/packages/wujie-core/src/index.ts
@@ -206,6 +206,7 @@ export async function startApp(startOptions: startOptions): Promise<Function | v
           fetch: fetch || window.fetch,
           plugins: sandbox.plugins,
           loadError: sandbox.lifecycles.loadError,
+          fiber,
         });
         await sandbox.start(getExternalScripts);
       }
@@ -239,6 +240,7 @@ export async function startApp(startOptions: startOptions): Promise<Function | v
     fetch: fetch || window.fetch,
     plugins: newSandbox.plugins,
     loadError: newSandbox.lifecycles.loadError,
+    fiber,
   });
 
   const processedHtml = await processCssLoader(newSandbox, template, getExternalStyleSheets);
@@ -271,6 +273,7 @@ export function preloadApp(preOptions: preOptions): void {
         fetch: fetch || window.fetch,
         plugins: sandbox.plugins,
         loadError: sandbox.lifecycles.loadError,
+        fiber,
       });
       const processedHtml = await processCssLoader(sandbox, template, getExternalStyleSheets);
       await sandbox.active({ url, props, prefix, alive, template: processedHtml, fetch, replace });


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [ ] 文档更改
- [ ] 测试用例添加
- [x] `npm run test`通过

##### 详细描述

- 特性
加载defer脚本的时候统一采用requestIdleCallback的方式，没有受fiber的管控
- 关联issue
#165 
