### PR TITLE
fix: 修复esm和jsIgnores脚本的onload事件没有触发

### DIFF
--- a/packages/wujie-core/src/effect.ts
+++ b/packages/wujie-core/src/effect.ts
@@ -223,14 +223,15 @@ function rewriteAppendOrInsertChild(opts: {
         case "SCRIPT": {
           const { src, text, type, crossOrigin } = element as HTMLScriptElement;
           // 排除js
-          if (!isMatchUrl(src, getEffectLoaders("jsExcludes", plugins))) {
+          if (src && !isMatchUrl(src, getEffectLoaders("jsExcludes", plugins))) {
             const execScript = (scriptResult: ScriptObject) => {
               // 假如子应用被连续渲染两次，两次渲染会导致处理流程的交叉污染
               if (sandbox.iframe === null) return warn(WUJIE_TIPS_REPEAT_RENDER);
-              insertScriptToIframe(scriptResult, sandbox.iframe.contentWindow);
-              // 只有外联转内联才需要手动触发load
-              if (scriptResult.content) manualInvokeElementEvent(element, "load");
-              element = null;
+              const onload = () => {
+                manualInvokeElementEvent(element, "load");
+                element = null;
+              };
+              insertScriptToIframe({ ...scriptResult, onload }, sandbox.iframe.contentWindow);
             };
             const scriptOptions = {
               src,

--- a/packages/wujie-core/src/iframe.ts
+++ b/packages/wujie-core/src/iframe.ts
@@ -650,7 +650,8 @@ export function syncIframeUrlToWindow(iframeWindow: Window): void {
  * @param iframeWindow
  */
 export function insertScriptToIframe(scriptResult: ScriptObject | ScriptObjectLoader, iframeWindow: Window) {
-  const { src, module, content, crossorigin, crossoriginType, async, callback } = scriptResult as ScriptObjectLoader;
+  const { src, module, content, crossorigin, crossoriginType, async, callback, onload } =
+    scriptResult as ScriptObjectLoader;
   const scriptElement = iframeWindow.document.createElement("script");
   const nextScriptElement = iframeWindow.document.createElement("script");
   const { replace, plugins, proxyLocation } = iframeWindow.__WUJIE;
@@ -674,6 +675,8 @@ export function insertScriptToIframe(scriptResult: ScriptObject | ScriptObjectLo
     Object.defineProperty(scriptElement, "src", { get: () => src || "" });
     // 非内联脚本
   } else {
+    // 外联自动触发onload
+    onload && (scriptElement.onload = onload as (this: GlobalEventHandlers, ev: Event) => any);
     src && scriptElement.setAttribute("src", src);
     crossorigin && scriptElement.setAttribute("crossorigin", crossoriginType);
   }
@@ -690,6 +693,8 @@ export function insertScriptToIframe(scriptResult: ScriptObject | ScriptObjectLo
   }
   container.appendChild(scriptElement);
 
+  // 外联转内联调用手动触发onload
+  content && onload?.();
   // 调用回调
   callback?.(iframeWindow);
 

--- a/packages/wujie-core/src/index.ts
+++ b/packages/wujie-core/src/index.ts
@@ -26,6 +26,8 @@ export interface ScriptObjectLoader {
   content?: string;
   /** 执行回调钩子 */
   callback?: (appWindow: Window) => any;
+  /** 子应用加载完毕事件 */
+  onload?: Function;
 }
 export interface plugin {
   /** 处理html的loader */

--- a/packages/wujie-core/src/template.ts
+++ b/packages/wujie-core/src/template.ts
@@ -42,6 +42,8 @@ export type ScriptObject = ScriptBaseObject & {
   content?: string;
   /** 忽略，子应用自行请求 */
   ignore?: boolean;
+  /** 子应用加载完毕事件 */
+  onload?: Function;
 };
 
 /** 样式对象 */


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [ ] 文档更改
- [ ] 测试用例添加
- [x] `npm run test`通过

##### 详细描述

- 特性
通过手动触发的方式触发外联脚本和外联转内联脚本的onload事件
- 关联issue
#210 
