### PR TITLE
fix: 修复无界主应用内嵌在iframe内部报错

### DIFF
--- a/docs/guide/jump.md
+++ b/docs/guide/jump.md
@@ -46,12 +46,11 @@ function handleJump() {
 ```javascript
 // 子应用 A 点击跳转处理函数
 function handleJump() {
-  window.$wujie?.props.jump({ path: "/pathB", query: { B: window.encodeURIComponent("/test") } });
+  window.$wujie?.props.jump({ path: "/pathB", query: { B: "/test" } });
 }
 ```
 
-由于跳转后的链接的查询参数带上了 B 应用的路径信息，而子应用 B 开启了路由同步的能力，所以能从 url 上读回需要同步的路径
-
+由于跳转后的链接的查询参数带上了 B 应用的路径信息，而子应用 B 开启了路由同步的能力，所以能从 url 上读回需要同步的路径，注意这种办法只有在 B 应用未曾激活过才生效。
 ### 子应用 B 为保活应用
 
 如果子应用 B 是保活应用并且没有被打开过，也就是还没有实例化，上述的打开指定路由的方式可以正常工作，但如果子应用 B 已经实例化，保活应用的内部数据和路由状态都会保存下来不随子应用切换而丢失。

--- a/packages/wujie-core/src/common.ts
+++ b/packages/wujie-core/src/common.ts
@@ -186,8 +186,6 @@ export const windowRegWhiteList = [
 
 // 保存原型方法
 // 子应用的Document.prototype已经被改写了
-export const rawCreateElement = window.top.Document.prototype.createElement;
-export const rawCreateTextNode = window.top.Document.prototype.createTextNode;
 export const rawElementAppendChild = HTMLElement.prototype.appendChild;
 export const rawElementRemoveChild = HTMLElement.prototype.removeChild;
 export const rawHeadInsertBefore = HTMLHeadElement.prototype.insertBefore;

--- a/packages/wujie-core/src/sandbox.ts
+++ b/packages/wujie-core/src/sandbox.ts
@@ -124,6 +124,8 @@ export default class Wujie {
     idToSandboxMap: Map<String, SandboxCache>;
     appEventObjMap: Map<String, EventObj>;
     mainHostPath: string;
+    rawCreateElement: typeof Document.prototype.createElement;
+    rawCreateTextNode: typeof Document.prototype.createTextNode;
   };
 
   /** 激活子应用
@@ -472,6 +474,8 @@ export default class Wujie {
         idToSandboxMap: idToSandboxCacheMap,
         appEventObjMap,
         mainHostPath: window.location.protocol + "//" + window.location.host,
+        rawCreateElement: window.document.createElement,
+        rawCreateTextNode: window.document.createTextNode,
       };
     }
     const { name, url, attrs, fiber, degrade, lifecycles, plugins } = options;


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [x] 文档更改
- [ ] 测试用例添加
- [x] `npm run test`通过

##### 详细描述

- 特性
由于需要使用原生的 createElement 和 createTextNode方法，需要从主应用获取，代码采用了 window.top.Docuemnt.prototype.xxx 来获取导致主应用内嵌在 iframe 中报错
- 关联issue
