### PR TITLE
fix: 兼容子应用通过href切换路由或添加路由参数

### DIFF
--- a/packages/wujie-core/src/proxy.ts
+++ b/packages/wujie-core/src/proxy.ts
@@ -16,12 +16,20 @@ import {
  * location href 的set劫持操作
  */
 function locationHrefSet(iframe: HTMLIFrameElement, value: string, appHostPath: string): boolean {
-  const { shadowRoot, id, degrade, document } = iframe.contentWindow.__WUJIE;
+  const { shadowRoot, id, degrade, document, proxyLocation } = iframe.contentWindow.__WUJIE;
   let url = value;
   if (!/^http/.test(url)) {
     let hrefElement = anchorElementGenerator(url);
     url = appHostPath + hrefElement.pathname + hrefElement.search + hrefElement.hash;
     hrefElement = null;
+  }
+  const originalHref = (proxyLocation as Location).href;
+  if (url === originalHref) {
+    return true
+  }
+  if (url.indexOf(originalHref) === 0) {
+    (proxyLocation as Location).replace(url)
+    return true
   }
   iframe.contentWindow.__WUJIE.hrefFlag = true;
   if (degrade) {


### PR DESCRIPTION
##### Checklist

- [x] 提交符合commit规范
- [ ] 测试用例添加
- [x] `npm run test`通过

##### 详细描述
在使用`wujie`过程中，我发现当子应用通过修改`location.href`进行切换路由或修改路由参数时，会被自动转为`iframe`加载。以至于那些子应用在交互过程中体验不佳（也许它仅是希望切换个内部页面，却出了重新加载的视觉现象）。

因此，希望能在转为`iframe`加载之前增加判断，如果是子应用内部的路由处理，能转为`location.replace`以贴近子应用预期。

- 特性
- 关联issue
#270 