### PR TITLE
feat: 增加degradeAttrs参数用于控制降级时的Iframe属性

### DIFF
--- a/packages/wujie-core/src/iframe.ts
+++ b/packages/wujie-core/src/iframe.ts
@@ -738,12 +738,12 @@ export function insertScriptToIframe(
 export function renderIframeReplaceApp(
   src: string,
   element: HTMLElement,
-  degrateAttrs: { [key: string]: any } = {}
+  degradeAttrs: { [key: string]: any } = {}
 ): void {
   const iframe = window.document.createElement("iframe");
   iframe.setAttribute("src", src);
   iframe.setAttribute("style", "height:100%;width:100%");
-  mergeAttrsToElement(iframe, degrateAttrs);
+  mergeAttrsToElement(iframe, degradeAttrs);
   renderElementToContainer(iframe, element);
 }
 

--- a/packages/wujie-core/src/iframe.ts
+++ b/packages/wujie-core/src/iframe.ts
@@ -734,10 +734,11 @@ export function insertScriptToIframe(
  * @param src 地址
  * @param shadowRoot
  */
-export function renderIframeReplaceApp(src: string, element: HTMLElement): void {
+export function renderIframeReplaceApp(src: string, element: HTMLElement, style: { [key: string]: string } = {}): void {
   const iframe = window.document.createElement("iframe");
   iframe.setAttribute("src", src);
   iframe.setAttribute("style", "height:100%;width:100%");
+  Object.assign(iframe.style, style);
   renderElementToContainer(iframe, element);
 }
 

--- a/packages/wujie-core/src/iframe.ts
+++ b/packages/wujie-core/src/iframe.ts
@@ -12,6 +12,7 @@ import {
   execHooks,
   getCurUrl,
   getAbsolutePath,
+  mergeAttrsToElement,
 } from "./utils";
 import {
   documentProxyProperties,
@@ -734,11 +735,15 @@ export function insertScriptToIframe(
  * @param src 地址
  * @param shadowRoot
  */
-export function renderIframeReplaceApp(src: string, element: HTMLElement, style: { [key: string]: string } = {}): void {
+export function renderIframeReplaceApp(
+  src: string,
+  element: HTMLElement,
+  degrateAttrs: { [key: string]: any } = {}
+): void {
   const iframe = window.document.createElement("iframe");
   iframe.setAttribute("src", src);
   iframe.setAttribute("style", "height:100%;width:100%");
-  Object.assign(iframe.style, style);
+  mergeAttrsToElement(iframe, degrateAttrs);
   renderElementToContainer(iframe, element);
 }
 

--- a/packages/wujie-core/src/index.ts
+++ b/packages/wujie-core/src/index.ts
@@ -90,8 +90,8 @@ type baseOptions = {
   props?: { [key: string]: any };
   /** 自定义iframe属性 */
   attrs?: { [key: string]: any };
-  /** 渲染iframe的样式 */
-  iframeStyle?: { [key: string]: string };
+  /** 降级时渲染iframe的属性 */
+  degrateAttrs?: { [key: string]: any };
   /** 子应用采用fiber模式执行 */
   fiber?: boolean;
   /** 子应用保活，state不会丢失 */
@@ -181,7 +181,7 @@ export async function startApp(startOptions: startOptions): Promise<Function | v
     fetch,
     props,
     attrs,
-    iframeStyle,
+    degrateAttrs,
     fiber,
     alive,
     degrade,
@@ -238,7 +238,7 @@ export async function startApp(startOptions: startOptions): Promise<Function | v
 
   // 设置loading
   addLoading(el, loading);
-  const newSandbox = new WuJie({ name, url, attrs, iframeStyle, fiber, degrade, plugins, lifecycles });
+  const newSandbox = new WuJie({ name, url, attrs, degrateAttrs, fiber, degrade, plugins, lifecycles });
   newSandbox.lifecycles?.beforeLoad?.(newSandbox.iframe.contentWindow);
   const { template, getExternalScripts, getExternalStyleSheets } = await importHTML(url, {
     fetch: fetch || window.fetch,
@@ -275,7 +275,7 @@ export function preloadApp(preOptions: preOptions): void {
       fetch,
       exec,
       attrs,
-      iframeStyle,
+      degrateAttrs,
       fiber,
       degrade,
       prefix,
@@ -283,7 +283,7 @@ export function preloadApp(preOptions: preOptions): void {
       lifecycles,
     } = options;
 
-    const sandbox = new WuJie({ name, url, attrs, iframeStyle, fiber, degrade, plugins, lifecycles });
+    const sandbox = new WuJie({ name, url, attrs, degrateAttrs, fiber, degrade, plugins, lifecycles });
     if (sandbox.preload) return sandbox.preload;
     const runPreload = async () => {
       sandbox.lifecycles?.beforeLoad?.(sandbox.iframe.contentWindow);

--- a/packages/wujie-core/src/index.ts
+++ b/packages/wujie-core/src/index.ts
@@ -91,7 +91,7 @@ type baseOptions = {
   /** 自定义iframe属性 */
   attrs?: { [key: string]: any };
   /** 降级时渲染iframe的属性 */
-  degrateAttrs?: { [key: string]: any };
+  degradeAttrs?: { [key: string]: any };
   /** 子应用采用fiber模式执行 */
   fiber?: boolean;
   /** 子应用保活，state不会丢失 */
@@ -181,7 +181,7 @@ export async function startApp(startOptions: startOptions): Promise<Function | v
     fetch,
     props,
     attrs,
-    degrateAttrs,
+    degradeAttrs,
     fiber,
     alive,
     degrade,
@@ -238,7 +238,7 @@ export async function startApp(startOptions: startOptions): Promise<Function | v
 
   // 设置loading
   addLoading(el, loading);
-  const newSandbox = new WuJie({ name, url, attrs, degrateAttrs, fiber, degrade, plugins, lifecycles });
+  const newSandbox = new WuJie({ name, url, attrs, degradeAttrs, fiber, degrade, plugins, lifecycles });
   newSandbox.lifecycles?.beforeLoad?.(newSandbox.iframe.contentWindow);
   const { template, getExternalScripts, getExternalStyleSheets } = await importHTML(url, {
     fetch: fetch || window.fetch,
@@ -275,7 +275,7 @@ export function preloadApp(preOptions: preOptions): void {
       fetch,
       exec,
       attrs,
-      degrateAttrs,
+      degradeAttrs,
       fiber,
       degrade,
       prefix,
@@ -283,7 +283,7 @@ export function preloadApp(preOptions: preOptions): void {
       lifecycles,
     } = options;
 
-    const sandbox = new WuJie({ name, url, attrs, degrateAttrs, fiber, degrade, plugins, lifecycles });
+    const sandbox = new WuJie({ name, url, attrs, degradeAttrs, fiber, degrade, plugins, lifecycles });
     if (sandbox.preload) return sandbox.preload;
     const runPreload = async () => {
       sandbox.lifecycles?.beforeLoad?.(sandbox.iframe.contentWindow);

--- a/packages/wujie-core/src/index.ts
+++ b/packages/wujie-core/src/index.ts
@@ -90,6 +90,8 @@ type baseOptions = {
   props?: { [key: string]: any };
   /** 自定义iframe属性 */
   attrs?: { [key: string]: any };
+  /** 渲染iframe的样式 */
+  iframeStyle?: { [key: string]: string };
   /** 子应用采用fiber模式执行 */
   fiber?: boolean;
   /** 子应用保活，state不会丢失 */
@@ -179,6 +181,7 @@ export async function startApp(startOptions: startOptions): Promise<Function | v
     fetch,
     props,
     attrs,
+    iframeStyle,
     fiber,
     alive,
     degrade,
@@ -235,7 +238,7 @@ export async function startApp(startOptions: startOptions): Promise<Function | v
 
   // 设置loading
   addLoading(el, loading);
-  const newSandbox = new WuJie({ name, url, attrs, fiber, degrade, plugins, lifecycles });
+  const newSandbox = new WuJie({ name, url, attrs, iframeStyle, fiber, degrade, plugins, lifecycles });
   newSandbox.lifecycles?.beforeLoad?.(newSandbox.iframe.contentWindow);
   const { template, getExternalScripts, getExternalStyleSheets } = await importHTML(url, {
     fetch: fetch || window.fetch,
@@ -263,10 +266,24 @@ export function preloadApp(preOptions: preOptions): void {
     const cacheOptions = getOptionsById(preOptions.name);
     // 合并缓存配置
     const options = mergeOptions({ ...preOptions }, cacheOptions);
-    const { name, url, props, alive, replace, fetch, exec, attrs, fiber, degrade, prefix, plugins, lifecycles } =
-      options;
+    const {
+      name,
+      url,
+      props,
+      alive,
+      replace,
+      fetch,
+      exec,
+      attrs,
+      iframeStyle,
+      fiber,
+      degrade,
+      prefix,
+      plugins,
+      lifecycles,
+    } = options;
 
-    const sandbox = new WuJie({ name, url, attrs, fiber, degrade, plugins, lifecycles });
+    const sandbox = new WuJie({ name, url, attrs, iframeStyle, fiber, degrade, plugins, lifecycles });
     if (sandbox.preload) return sandbox.preload;
     const runPreload = async () => {
       sandbox.lifecycles?.beforeLoad?.(sandbox.iframe.contentWindow);

--- a/packages/wujie-core/src/proxy.ts
+++ b/packages/wujie-core/src/proxy.ts
@@ -16,7 +16,7 @@ import {
  * location href 的set劫持操作
  */
 function locationHrefSet(iframe: HTMLIFrameElement, value: string, appHostPath: string): boolean {
-  const { shadowRoot, id, degrade, document } = iframe.contentWindow.__WUJIE;
+  const { shadowRoot, id, degrade, document, iframeStyle } = iframe.contentWindow.__WUJIE;
   let url = value;
   if (!/^http/.test(url)) {
     let hrefElement = anchorElementGenerator(url);
@@ -27,8 +27,8 @@ function locationHrefSet(iframe: HTMLIFrameElement, value: string, appHostPath: 
   if (degrade) {
     const iframeBody = rawDocumentQuerySelector.call(iframe.contentDocument, "body");
     renderElementToContainer(document.documentElement, iframeBody);
-    renderIframeReplaceApp(window.decodeURIComponent(url), getDegradeIframe(id).parentElement);
-  } else renderIframeReplaceApp(url, shadowRoot.host.parentElement);
+    renderIframeReplaceApp(window.decodeURIComponent(url), getDegradeIframe(id).parentElement, iframeStyle);
+  } else renderIframeReplaceApp(url, shadowRoot.host.parentElement, iframeStyle);
   pushUrlToWindow(id, url);
   return true;
 }

--- a/packages/wujie-core/src/proxy.ts
+++ b/packages/wujie-core/src/proxy.ts
@@ -16,7 +16,7 @@ import {
  * location href 的set劫持操作
  */
 function locationHrefSet(iframe: HTMLIFrameElement, value: string, appHostPath: string): boolean {
-  const { shadowRoot, id, degrade, document, iframeStyle } = iframe.contentWindow.__WUJIE;
+  const { shadowRoot, id, degrade, document, degrateAttrs } = iframe.contentWindow.__WUJIE;
   let url = value;
   if (!/^http/.test(url)) {
     let hrefElement = anchorElementGenerator(url);
@@ -27,8 +27,8 @@ function locationHrefSet(iframe: HTMLIFrameElement, value: string, appHostPath: 
   if (degrade) {
     const iframeBody = rawDocumentQuerySelector.call(iframe.contentDocument, "body");
     renderElementToContainer(document.documentElement, iframeBody);
-    renderIframeReplaceApp(window.decodeURIComponent(url), getDegradeIframe(id).parentElement, iframeStyle);
-  } else renderIframeReplaceApp(url, shadowRoot.host.parentElement, iframeStyle);
+    renderIframeReplaceApp(window.decodeURIComponent(url), getDegradeIframe(id).parentElement, degrateAttrs);
+  } else renderIframeReplaceApp(url, shadowRoot.host.parentElement, degrateAttrs);
   pushUrlToWindow(id, url);
   return true;
 }

--- a/packages/wujie-core/src/proxy.ts
+++ b/packages/wujie-core/src/proxy.ts
@@ -16,7 +16,7 @@ import {
  * location href 的set劫持操作
  */
 function locationHrefSet(iframe: HTMLIFrameElement, value: string, appHostPath: string): boolean {
-  const { shadowRoot, id, degrade, document, degrateAttrs } = iframe.contentWindow.__WUJIE;
+  const { shadowRoot, id, degrade, document, degradeAttrs } = iframe.contentWindow.__WUJIE;
   let url = value;
   if (!/^http/.test(url)) {
     let hrefElement = anchorElementGenerator(url);
@@ -27,8 +27,8 @@ function locationHrefSet(iframe: HTMLIFrameElement, value: string, appHostPath: 
   if (degrade) {
     const iframeBody = rawDocumentQuerySelector.call(iframe.contentDocument, "body");
     renderElementToContainer(document.documentElement, iframeBody);
-    renderIframeReplaceApp(window.decodeURIComponent(url), getDegradeIframe(id).parentElement, degrateAttrs);
-  } else renderIframeReplaceApp(url, shadowRoot.host.parentElement, degrateAttrs);
+    renderIframeReplaceApp(window.decodeURIComponent(url), getDegradeIframe(id).parentElement, degradeAttrs);
+  } else renderIframeReplaceApp(url, shadowRoot.host.parentElement, degradeAttrs);
   pushUrlToWindow(id, url);
   return true;
 }

--- a/packages/wujie-core/src/sandbox.ts
+++ b/packages/wujie-core/src/sandbox.ts
@@ -81,8 +81,8 @@ export default class Wujie {
   public iframeReady: Promise<void>;
   /** 子应用预加载态 */
   public preload: Promise<void>;
-  /** iframe 渲染子应用时的样式 */
-  public iframeStyle: { [key: string]: string };
+  /** 降级时渲染iframe的属性 */
+  public degrateAttrs: { [key: string]: any };
   /** 子应用js执行队列 */
   public execQueue: Array<Function>;
   /** 子应用执行标志 */
@@ -185,7 +185,7 @@ export default class Wujie {
 
     /* 降级处理 */
     if (this.degrade) {
-      const iframe = createIframeContainer(this.id, this.iframeStyle);
+      const iframe = createIframeContainer(this.id, this.degrateAttrs);
       const iframeBody = rawDocumentQuerySelector.call(iframeWindow.document, "body") as HTMLElement;
       this.el = renderElementToContainer(iframe, el ?? iframeBody);
       clearChild(iframe.contentDocument);
@@ -389,7 +389,7 @@ export default class Wujie {
     this.proxyLocation = null;
     this.execQueue = null;
     this.provide = null;
-    this.iframeStyle = null;
+    this.degrateAttrs = null;
     this.styleSheetElements = null;
     this.bus = null;
     this.replace = null;
@@ -461,7 +461,7 @@ export default class Wujie {
     name: string;
     url: string;
     attrs: { [key: string]: any };
-    iframeStyle: { [key: string]: any };
+    degrateAttrs: { [key: string]: any };
     fiber: boolean;
     degrade;
     plugins: Array<plugin>;
@@ -478,13 +478,13 @@ export default class Wujie {
         rawCreateTextNode: window.document.createTextNode,
       };
     }
-    const { name, url, attrs, fiber, iframeStyle, degrade, lifecycles, plugins } = options;
+    const { name, url, attrs, fiber, degrateAttrs, degrade, lifecycles, plugins } = options;
     this.id = name;
     this.fiber = fiber;
     this.degrade = degrade || !wujieSupport;
     this.bus = new EventBus(this.id);
     this.url = url;
-    this.iframeStyle = iframeStyle;
+    this.degrateAttrs = degrateAttrs;
     this.provide = { bus: this.bus };
     this.styleSheetElements = [];
     this.execQueue = [];

--- a/packages/wujie-core/src/sandbox.ts
+++ b/packages/wujie-core/src/sandbox.ts
@@ -389,6 +389,7 @@ export default class Wujie {
     this.proxyLocation = null;
     this.execQueue = null;
     this.provide = null;
+    this.iframeStyle = null;
     this.styleSheetElements = null;
     this.bus = null;
     this.replace = null;

--- a/packages/wujie-core/src/sandbox.ts
+++ b/packages/wujie-core/src/sandbox.ts
@@ -81,6 +81,8 @@ export default class Wujie {
   public iframeReady: Promise<void>;
   /** 子应用预加载态 */
   public preload: Promise<void>;
+  /** iframe 渲染子应用时的样式 */
+  public iframeStyle: { [key: string]: string };
   /** 子应用js执行队列 */
   public execQueue: Array<Function>;
   /** 子应用执行标志 */
@@ -183,7 +185,7 @@ export default class Wujie {
 
     /* 降级处理 */
     if (this.degrade) {
-      const iframe = createIframeContainer(this.id);
+      const iframe = createIframeContainer(this.id, this.iframeStyle);
       const iframeBody = rawDocumentQuerySelector.call(iframeWindow.document, "body") as HTMLElement;
       this.el = renderElementToContainer(iframe, el ?? iframeBody);
       clearChild(iframe.contentDocument);
@@ -458,6 +460,7 @@ export default class Wujie {
     name: string;
     url: string;
     attrs: { [key: string]: any };
+    iframeStyle: { [key: string]: any };
     fiber: boolean;
     degrade;
     plugins: Array<plugin>;
@@ -474,12 +477,13 @@ export default class Wujie {
         rawCreateTextNode: window.document.createTextNode,
       };
     }
-    const { name, url, attrs, fiber, degrade, lifecycles, plugins } = options;
+    const { name, url, attrs, fiber, iframeStyle, degrade, lifecycles, plugins } = options;
     this.id = name;
     this.fiber = fiber;
     this.degrade = degrade || !wujieSupport;
     this.bus = new EventBus(this.id);
     this.url = url;
+    this.iframeStyle = iframeStyle;
     this.provide = { bus: this.bus };
     this.styleSheetElements = [];
     this.execQueue = [];

--- a/packages/wujie-core/src/sandbox.ts
+++ b/packages/wujie-core/src/sandbox.ts
@@ -82,7 +82,7 @@ export default class Wujie {
   /** 子应用预加载态 */
   public preload: Promise<void>;
   /** 降级时渲染iframe的属性 */
-  public degrateAttrs: { [key: string]: any };
+  public degradeAttrs: { [key: string]: any };
   /** 子应用js执行队列 */
   public execQueue: Array<Function>;
   /** 子应用执行标志 */
@@ -185,7 +185,7 @@ export default class Wujie {
 
     /* 降级处理 */
     if (this.degrade) {
-      const iframe = createIframeContainer(this.id, this.degrateAttrs);
+      const iframe = createIframeContainer(this.id, this.degradeAttrs);
       const iframeBody = rawDocumentQuerySelector.call(iframeWindow.document, "body") as HTMLElement;
       this.el = renderElementToContainer(iframe, el ?? iframeBody);
       clearChild(iframe.contentDocument);
@@ -389,7 +389,7 @@ export default class Wujie {
     this.proxyLocation = null;
     this.execQueue = null;
     this.provide = null;
-    this.degrateAttrs = null;
+    this.degradeAttrs = null;
     this.styleSheetElements = null;
     this.bus = null;
     this.replace = null;
@@ -461,7 +461,7 @@ export default class Wujie {
     name: string;
     url: string;
     attrs: { [key: string]: any };
-    degrateAttrs: { [key: string]: any };
+    degradeAttrs: { [key: string]: any };
     fiber: boolean;
     degrade;
     plugins: Array<plugin>;
@@ -478,13 +478,13 @@ export default class Wujie {
         rawCreateTextNode: window.document.createTextNode,
       };
     }
-    const { name, url, attrs, fiber, degrateAttrs, degrade, lifecycles, plugins } = options;
+    const { name, url, attrs, fiber, degradeAttrs, degrade, lifecycles, plugins } = options;
     this.id = name;
     this.fiber = fiber;
     this.degrade = degrade || !wujieSupport;
     this.bus = new EventBus(this.id);
     this.url = url;
-    this.degrateAttrs = degrateAttrs;
+    this.degradeAttrs = degradeAttrs;
     this.provide = { bus: this.bus };
     this.styleSheetElements = [];
     this.execQueue = [];

--- a/packages/wujie-core/src/shadow.ts
+++ b/packages/wujie-core/src/shadow.ts
@@ -218,10 +218,11 @@ export async function renderTemplateToShadowRoot(
   patchRenderEffect(shadowRoot, iframeWindow.__WUJIE.id, false);
 }
 
-export function createIframeContainer(id: string): HTMLIFrameElement {
+export function createIframeContainer(id: string, style: { [key: string]: string } = {}): HTMLIFrameElement {
   const iframe = document.createElement("iframe");
   iframe.setAttribute("style", "width: 100%; height:100%");
   iframe.setAttribute(WUJIE_DATA_ID, id);
+  Object.assign(iframe.style, style);
   return iframe;
 }
 

--- a/packages/wujie-core/src/shadow.ts
+++ b/packages/wujie-core/src/shadow.ts
@@ -20,7 +20,7 @@ import Wujie from "./sandbox";
 import { patchElementEffect } from "./iframe";
 import { patchRenderEffect } from "./effect";
 import { getCssLoader, getPresetLoaders } from "./plugin";
-import { getAbsolutePath, getContainer, getCurUrl } from "./utils";
+import { getAbsolutePath, getContainer, getCurUrl, mergeAttrsToElement } from "./utils";
 
 const cssSelectorMap = {
   ":root": ":host",
@@ -218,11 +218,11 @@ export async function renderTemplateToShadowRoot(
   patchRenderEffect(shadowRoot, iframeWindow.__WUJIE.id, false);
 }
 
-export function createIframeContainer(id: string, style: { [key: string]: string } = {}): HTMLIFrameElement {
+export function createIframeContainer(id: string, degrateAttrs: { [key: string]: any } = {}): HTMLIFrameElement {
   const iframe = document.createElement("iframe");
   iframe.setAttribute("style", "width: 100%; height:100%");
   iframe.setAttribute(WUJIE_DATA_ID, id);
-  Object.assign(iframe.style, style);
+  mergeAttrsToElement(iframe, degrateAttrs);
   return iframe;
 }
 

--- a/packages/wujie-core/src/shadow.ts
+++ b/packages/wujie-core/src/shadow.ts
@@ -218,11 +218,11 @@ export async function renderTemplateToShadowRoot(
   patchRenderEffect(shadowRoot, iframeWindow.__WUJIE.id, false);
 }
 
-export function createIframeContainer(id: string, degrateAttrs: { [key: string]: any } = {}): HTMLIFrameElement {
+export function createIframeContainer(id: string, degradeAttrs: { [key: string]: any } = {}): HTMLIFrameElement {
   const iframe = document.createElement("iframe");
   iframe.setAttribute("style", "width: 100%; height:100%");
   iframe.setAttribute(WUJIE_DATA_ID, id);
-  mergeAttrsToElement(iframe, degrateAttrs);
+  mergeAttrsToElement(iframe, degradeAttrs);
   return iframe;
 }
 

--- a/packages/wujie-core/src/sync.ts
+++ b/packages/wujie-core/src/sync.ts
@@ -130,14 +130,23 @@ export function processAppForHrefJump(): void {
         if (/http/.test(url)) {
           if (sandbox.degrade) {
             renderElementToContainer(sandbox.document.documentElement, iframeBody);
-            renderIframeReplaceApp(window.decodeURIComponent(url), getDegradeIframe(sandbox.id).parentElement);
-          } else renderIframeReplaceApp(window.decodeURIComponent(url), sandbox.shadowRoot.host.parentElement);
+            renderIframeReplaceApp(
+              window.decodeURIComponent(url),
+              getDegradeIframe(sandbox.id).parentElement,
+              sandbox.iframeStyle
+            );
+          } else
+            renderIframeReplaceApp(
+              window.decodeURIComponent(url),
+              sandbox.shadowRoot.host.parentElement,
+              sandbox.iframeStyle
+            );
           sandbox.hrefFlag = true;
           // href后退
         } else if (sandbox.hrefFlag) {
           if (sandbox.degrade) {
             // 走全套流程，但是事件恢复不需要
-            const iframe = createIframeContainer(sandbox.id);
+            const iframe = createIframeContainer(sandbox.id, sandbox.iframeStyle);
             renderElementToContainer(iframe, sandbox.el);
             clearChild(iframe.contentDocument);
             patchEventTimeStamp(iframe.contentWindow, sandbox.iframe.contentWindow);

--- a/packages/wujie-core/src/sync.ts
+++ b/packages/wujie-core/src/sync.ts
@@ -133,20 +133,20 @@ export function processAppForHrefJump(): void {
             renderIframeReplaceApp(
               window.decodeURIComponent(url),
               getDegradeIframe(sandbox.id).parentElement,
-              sandbox.degrateAttrs
+              sandbox.degradeAttrs
             );
           } else
             renderIframeReplaceApp(
               window.decodeURIComponent(url),
               sandbox.shadowRoot.host.parentElement,
-              sandbox.degrateAttrs
+              sandbox.degradeAttrs
             );
           sandbox.hrefFlag = true;
           // href后退
         } else if (sandbox.hrefFlag) {
           if (sandbox.degrade) {
             // 走全套流程，但是事件恢复不需要
-            const iframe = createIframeContainer(sandbox.id, sandbox.degrateAttrs);
+            const iframe = createIframeContainer(sandbox.id, sandbox.degradeAttrs);
             renderElementToContainer(iframe, sandbox.el);
             clearChild(iframe.contentDocument);
             patchEventTimeStamp(iframe.contentWindow, sandbox.iframe.contentWindow);

--- a/packages/wujie-core/src/sync.ts
+++ b/packages/wujie-core/src/sync.ts
@@ -133,20 +133,20 @@ export function processAppForHrefJump(): void {
             renderIframeReplaceApp(
               window.decodeURIComponent(url),
               getDegradeIframe(sandbox.id).parentElement,
-              sandbox.iframeStyle
+              sandbox.degrateAttrs
             );
           } else
             renderIframeReplaceApp(
               window.decodeURIComponent(url),
               sandbox.shadowRoot.host.parentElement,
-              sandbox.iframeStyle
+              sandbox.degrateAttrs
             );
           sandbox.hrefFlag = true;
           // href后退
         } else if (sandbox.hrefFlag) {
           if (sandbox.degrade) {
             // 走全套流程，但是事件恢复不需要
-            const iframe = createIframeContainer(sandbox.id, sandbox.iframeStyle);
+            const iframe = createIframeContainer(sandbox.id, sandbox.degrateAttrs);
             renderElementToContainer(iframe, sandbox.el);
             clearChild(iframe.contentDocument);
             patchEventTimeStamp(iframe.contentWindow, sandbox.iframe.contentWindow);

--- a/packages/wujie-core/src/utils.ts
+++ b/packages/wujie-core/src/utils.ts
@@ -310,7 +310,7 @@ export function mergeOptions(options: cacheOptions, cacheOptions: cacheOptions) 
     loading: options.loading || cacheOptions?.loading,
     // 默认 {}
     attrs: options.attrs !== undefined ? options.attrs : cacheOptions?.attrs || {},
-    degrateAttrs: options.degrateAttrs !== undefined ? options.degrateAttrs : cacheOptions?.degrateAttrs || {},
+    degradeAttrs: options.degradeAttrs !== undefined ? options.degradeAttrs : cacheOptions?.degradeAttrs || {},
     // 默认 true
     fiber: options.fiber !== undefined ? options.fiber : cacheOptions?.fiber !== undefined ? cacheOptions?.fiber : true,
     alive: options.alive !== undefined ? options.alive : cacheOptions?.alive,

--- a/packages/wujie-core/src/utils.ts
+++ b/packages/wujie-core/src/utils.ts
@@ -292,6 +292,7 @@ export function mergeOptions(options: cacheOptions, cacheOptions: cacheOptions) 
     loading: options.loading || cacheOptions?.loading,
     // 默认 {}
     attrs: options.attrs !== undefined ? options.attrs : cacheOptions?.attrs || {},
+    iframeStyle: options.iframeStyle !== undefined ? options.iframeStyle : cacheOptions?.iframeStyle || {},
     // 默认 true
     fiber: options.fiber !== undefined ? options.fiber : cacheOptions?.fiber !== undefined ? cacheOptions?.fiber : true,
     alive: options.alive !== undefined ? options.alive : cacheOptions?.alive,

--- a/packages/wujie-core/src/utils.ts
+++ b/packages/wujie-core/src/utils.ts
@@ -107,6 +107,24 @@ export function getDegradeIframe(id: string): HTMLIFrameElement {
   return window.document.querySelector(`iframe[${WUJIE_DATA_ID}="${id}"]`);
 }
 
+export function mergeAttrsToElement(element: HTMLElement, attrs: { [key: string]: any }) {
+  Object.keys(attrs).forEach((name) => {
+    if (name === "style") {
+      const style: { [key: string]: string } = {};
+      const styleAttrs = attrs[name].split(";");
+      styleAttrs.forEach((styleAttr) => {
+        if (styleAttr && styleAttr.length) {
+          const [key, value] = styleAttr.split(":");
+          style[key.trim()] = value.trim();
+        }
+      });
+      Object.assign(element.style, style);
+    } else {
+      element.setAttribute(name, attrs[name]);
+    }
+  });
+}
+
 export function appRouteParse(url: string): {
   urlElement: HTMLAnchorElement;
   appHostPath: string;
@@ -292,7 +310,7 @@ export function mergeOptions(options: cacheOptions, cacheOptions: cacheOptions) 
     loading: options.loading || cacheOptions?.loading,
     // 默认 {}
     attrs: options.attrs !== undefined ? options.attrs : cacheOptions?.attrs || {},
-    iframeStyle: options.iframeStyle !== undefined ? options.iframeStyle : cacheOptions?.iframeStyle || {},
+    degrateAttrs: options.degrateAttrs !== undefined ? options.degrateAttrs : cacheOptions?.degrateAttrs || {},
     // 默认 true
     fiber: options.fiber !== undefined ? options.fiber : cacheOptions?.fiber !== undefined ? cacheOptions?.fiber : true,
     alive: options.alive !== undefined ? options.alive : cacheOptions?.alive,


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [ ] 测试用例添加
- [x] `npm run test`通过

##### 详细描述
在子应用需要自动转为iframe渲染的场景（如降级、替换整个location.href），用于渲染的iframe目前的style只有width: 100%; height:100%。
希望能增加一个参数，方便主应用将一些常用的样式（如minHeight、minWidth）传递给用于渲染的iframe。
- 特性
- 关联issue
#271 