### PR TITLE
fix: 兼容主应用拦截原生的createElement

### DIFF
--- a/packages/wujie-core/src/iframe.ts
+++ b/packages/wujie-core/src/iframe.ts
@@ -41,6 +41,13 @@ declare global {
     __WUJIE_PUBLIC_PATH__: string;
     // 原生的querySelector
     __WUJIE_RAW_DOCUMENT_QUERY_SELECTOR__: typeof Document.prototype.querySelector;
+
+    // iframe内原生的createElement
+    __WUJIE_RAW_DOCUMENT_CREATE_ELEMENT__: typeof Document.prototype.createElement;
+
+    // iframe内原生的createTextNode
+    __WUJIE_RAW_DOCUMENT_CREATE_TEXT_NODE__: typeof Document.prototype.createTextNode;
+
     // 原生的querySelector
     __WUJIE_RAW_DOCUMENT_QUERY_SELECTOR_ALL__: typeof Document.prototype.querySelectorAll;
     // 原生的window对象
@@ -132,6 +139,8 @@ function patchIframeVariable(iframeWindow: Window, wujie: WuJie, appHostPath: st
   iframeWindow.__WUJIE_RAW_WINDOW__ = iframeWindow;
   iframeWindow.__WUJIE_RAW_DOCUMENT_QUERY_SELECTOR__ = iframeWindow.Document.prototype.querySelector;
   iframeWindow.__WUJIE_RAW_DOCUMENT_QUERY_SELECTOR_ALL__ = iframeWindow.Document.prototype.querySelectorAll;
+  iframeWindow.__WUJIE_RAW_DOCUMENT_CREATE_ELEMENT__ = iframeWindow.Document.prototype.createElement;
+  iframeWindow.__WUJIE_RAW_DOCUMENT_CREATE_TEXT_NODE__ = iframeWindow.Document.prototype.createTextNode;
 }
 
 /**

--- a/packages/wujie-core/src/proxy.ts
+++ b/packages/wujie-core/src/proxy.ts
@@ -79,12 +79,14 @@ export function proxyGenerator(
     {
       get: function (_fakeDocument, propKey) {
         const document = window.document;
-        const { shadowRoot, inject, proxyLocation } = iframe.contentWindow.__WUJIE;
+        const { shadowRoot, proxyLocation } = iframe.contentWindow.__WUJIE;
+        const rawCreateElement = iframe.contentWindow.__WUJIE_RAW_DOCUMENT_CREATE_ELEMENT__;
+        const rawCreateTextNode = iframe.contentWindow.__WUJIE_RAW_DOCUMENT_CREATE_TEXT_NODE__;
         // need fix
         if (propKey === "createElement" || propKey === "createTextNode") {
           return new Proxy(document[propKey], {
             apply(_createElement, _ctx, args) {
-              const rawCreateMethod = propKey === "createElement" ? inject.rawCreateElement : inject.rawCreateTextNode;
+              const rawCreateMethod = propKey === "createElement" ? rawCreateElement : rawCreateTextNode;
               const element = rawCreateMethod.apply(iframe.contentDocument, args);
               patchElementEffect(element, iframe.contentWindow);
               return element;
@@ -212,12 +214,14 @@ export function localGenerator(
   // 代理 document
   const proxyDocument = {};
   const sandbox = iframe.contentWindow.__WUJIE;
+  const rawCreateElement = iframe.contentWindow.__WUJIE_RAW_DOCUMENT_CREATE_ELEMENT__;
+  const rawCreateTextNode = iframe.contentWindow.__WUJIE_RAW_DOCUMENT_CREATE_TEXT_NODE__;
   // 特殊处理
   Object.defineProperties(proxyDocument, {
     createElement: {
       get: () => {
         return function (...args) {
-          const element = sandbox.inject.rawCreateElement.apply(iframe.contentDocument, args);
+          const element = rawCreateElement.apply(iframe.contentDocument, args);
           patchElementEffect(element, iframe.contentWindow);
           return element;
         };
@@ -226,7 +230,7 @@ export function localGenerator(
     createTextNode: {
       get: () => {
         return function (...args) {
-          const element = sandbox.inject.rawCreateTextNode.apply(iframe.contentDocument, args);
+          const element = rawCreateTextNode.apply(iframe.contentDocument, args);
           patchElementEffect(element, iframe.contentWindow);
           return element;
         };

--- a/packages/wujie-core/src/sandbox.ts
+++ b/packages/wujie-core/src/sandbox.ts
@@ -124,8 +124,6 @@ export default class Wujie {
     idToSandboxMap: Map<String, SandboxCache>;
     appEventObjMap: Map<String, EventObj>;
     mainHostPath: string;
-    rawCreateElement: typeof Document.prototype.createElement;
-    rawCreateTextNode: typeof Document.prototype.createTextNode;
   };
 
   /** 激活子应用
@@ -470,8 +468,6 @@ export default class Wujie {
         idToSandboxMap: idToSandboxCacheMap,
         appEventObjMap,
         mainHostPath: window.location.protocol + "//" + window.location.host,
-        rawCreateElement: window.document.createElement,
-        rawCreateTextNode: window.document.createTextNode,
       };
     }
     const { name, url, attrs, fiber, degrade, lifecycles, plugins } = options;


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [ ] 测试用例添加
- [x] `npm run test`通过

##### 详细描述
当主应用需要拦截原生的`createElement`时，自然会将`createElement`的`this`指向主应用的`document`。
然而，目前在`wujie`的`proxyDocument`中，是统一使用主应用的`createElement`，并尝试将`this`指向`iframe`的`document`。

在使用过程中发现，如果`wujie`的`proxyDocument`中，执行了被主应用改写过的`createElement`导致`this`最终指向主应用的`document`，会导致子应用内的节点，`element instanceof HTMLElement` 得到`false`。

因此，在`wujie`的`proxyDocument`中改为使用同域`iframe`的`createElement`方法。
- 特性
- 关联issue
#274 