### PR TITLE
docs(guide): 修复标签大小写不一致

### DIFF
--- a/docs/guide/jump.md
+++ b/docs/guide/jump.md
@@ -87,7 +87,7 @@ window.$wujie?.bus.$on("routeChange", (path) => this.$router.push({ path }));
 
 ```vue
 <template>
-  <wujie-vue name="A" url="//hostA.com" :props="{jump}" ></WujieVue>
+  <wujie-vue name="A" url="//hostA.com" :props="{jump}" ></wujie-vue>
 </template>
 
 <script>


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [x] 文档更改

##### 详细描述

- 修复 `指南-路由跳转` 文档中的组件标签大小写不一致
