### PR TITLE
fix: 修复:root[属性]失效

### DIFF
--- a/packages/wujie-core/src/shadow.ts
+++ b/packages/wujie-core/src/shadow.ts
@@ -323,7 +323,7 @@ export function removeLoading(el: HTMLElement): void {
 export function getPatchStyleElements(rootStyleSheets: Array<CSSStyleSheet>): Array<HTMLStyleElement | null> {
   const rootCssRules = [];
   const fontCssRules = [];
-  const rootStyleReg = /:root/g;
+  const rootStyleReg = /^:root(\[.*\])|:root/g;
 
   // 找出root的cssRules
   for (let i = 0; i < rootStyleSheets.length; i++) {
@@ -332,7 +332,15 @@ export function getPatchStyleElements(rootStyleSheets: Array<CSSStyleSheet>): Ar
       const cssRuleText = cssRules[j].cssText;
       // 如果是root的cssRule
       if (rootStyleReg.test(cssRuleText)) {
-        rootCssRules.push(cssRuleText.replace(rootStyleReg, (match) => cssSelectorMap[match]));
+        rootCssRules.push(
+          cssRuleText.replace(rootStyleReg, (match, attr) => {
+            if (attr) {
+              // 取match前5个字符，并将属性挂到html上
+              return `${cssSelectorMap[match.slice(0, 5)]} html${attr}`;
+            }
+            return cssSelectorMap[match];
+          })
+        );
       }
       // 如果是font-face的cssRule
       if (cssRules[j].type === CSSRule.FONT_FACE_RULE) {


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md -->

修复子应用`:root`样式问题

## 复现
子应用定义
```css
:root[data-theme="dark"]{'
    --color1: #f16b5f;
}
```

主应用被转换为
```
:host{
   --color1: #f16b5f;
}
```

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [ ] 文档更改
- [ ] 测试用例添加
- [ ] `npm run test`通过

##### 详细描述

- 特性
- 关联issue
