### PR TITLE
fix: 调整保活模式下路由同步的时机

### DIFF
--- a/packages/wujie-core/src/sandbox.ts
+++ b/packages/wujie-core/src/sandbox.ts
@@ -169,10 +169,7 @@ export default class Wujie {
     }
 
     // 处理子应用路由同步
-    if (this.execFlag && this.alive) {
-      // 当保活模式下子应用重新激活时，只需要将子应用路径同步回主应用
-      syncUrlToWindow(iframeWindow);
-    } else {
+    if (!this.execFlag || !this.alive) {
       // 先将url同步回iframe，然后再同步回浏览器url
       syncUrlToIframe(iframeWindow);
       syncUrlToWindow(iframeWindow);
@@ -219,7 +216,11 @@ export default class Wujie {
        this may lead memory leak risk
        */
       this.el = renderElementToContainer(this.shadowRoot.host, el);
-      if (this.alive) return;
+      if (this.alive) {
+        // 保活模式下子应用重新激活时，需要将子应用路径同步回主应用
+        syncUrlToWindow(this.iframe.contentWindow);
+        return;
+      }
     } else {
       // 预执行无容器，暂时插入iframe内部触发Web Component的connect
       const iframeBody = rawDocumentQuerySelector.call(iframeWindow.document, "body") as HTMLElement;


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [ ] 文档更改
- [ ] 测试用例添加
- [x] `npm run test`通过

##### 详细描述
此PR仅用于说明：
同一页面，切换保活应用时，如果同步路由的时机调整到Shadow DOM移除之后，路由参数显示正常。

- 特性
- 关联issue
#320 