### PR TITLE
fix: 修复子应用html加载失败后无法重试

### DIFF
--- a/packages/wujie-core/src/entry.ts
+++ b/packages/wujie-core/src/entry.ts
@@ -212,6 +212,7 @@ export default function importHTML(params: {
       : fetch(url).then(
           (response) => response.text(),
           (e) => {
+            embedHTMLCache[url] = null;
             loadError?.(url, e);
             return Promise.reject(e);
           }


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [ ] 文档更改
- [ ] 测试用例添加
- [x] `npm run test`通过

##### 详细描述
子应用 html 请求失败后，切换子应用后，失败的子应用不会重新发起 html 请求
- 特性
- 关联issue
