### PR TITLE
fix: 修复预加载js资源没有下载

### DIFF
--- a/packages/wujie-core/src/index.ts
+++ b/packages/wujie-core/src/index.ts
@@ -315,6 +315,8 @@ export function preloadApp(preOptions: preOptions): void {
       await sandbox.active({ url, props, prefix, alive, template: processedHtml, fetch, replace });
       if (exec) {
         await sandbox.start(getExternalScripts);
+      } else {
+        await getExternalScripts();
       }
     };
     sandbox.preload = runPreload();


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [ ] 文档更改
- [ ] 测试用例添加
- [x] `npm run test`通过

##### 详细描述

- 特性
非预执行场景下的预加载，js资源没有提前加载下来
- 关联issue
