### PR TITLE
chore: remove useless Promise.resolve()

### DIFF
--- a/packages/wujie-core/src/index.ts
+++ b/packages/wujie-core/src/index.ts
@@ -203,7 +203,7 @@ export async function startApp(startOptions: startOptions): Promise<Function | v
     sandbox.lifecycles = lifecycles;
     const iframeWindow = sandbox.iframe.contentWindow;
     if (sandbox.preload) {
-      await Promise.resolve(sandbox.preload);
+      await sandbox.preload;
     }
     if (alive) {
       // 保活


### PR DESCRIPTION
所以似乎没有必要：`sandbox.preload` 已经是Promise，`Promise.resolve()` 只会返回它自身。

<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [ ] 文档更改
- [ ] 测试用例添加
- [x] `npm run test`通过

##### 详细描述

- 特性
- 关联issue
