### PR TITLE
wujie-core/src/utils.ts execHooks 方法修改

### DIFF
--- a/packages/wujie-core/src/utils.ts
+++ b/packages/wujie-core/src/utils.ts
@@ -274,10 +274,12 @@ export function nextTick(cb: () => any): void {
 //执行钩子函数
 export function execHooks(plugins: Array<plugin>, hookName: string, ...args: Array<any>): void {
   try {
-    plugins
-      .map((plugin) => plugin[hookName])
-      .filter((hook) => isFunction(hook))
-      .forEach((hook) => hook(...args));
+    if(plugins&&plugins.length>0){
+      plugins
+        .map((plugin) => plugin[hookName])
+        .filter((hook) => isFunction(hook))
+        .forEach((hook) => hook(...args));
+    }
   } catch (e) {
     error(e);
   }


### PR DESCRIPTION
 execHooks  增加 plugins数据的校验
在我本地开发过程中 

vue2父应用 内 使用了个vue3+elementplus版的子应用
交互bug不得已 需要每次离开当前父应用页面时 销毁使用的子应用

但是跳转时 控制台有error报错
[wujie error]: TypeError: Cannot read properties of null (reading 'map') undefined 看了一下源码 应该是 子应用被销毁后 无界还在读取子应用的 plugins，子应用被销毁前是有个cssLoader的  销毁后不存在了 所以就抛出error了

这个地方增加一层判断就可以了【ps 微信群反馈过哈】

<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [ ] 提交符合commit规范
- [ ] 文档更改
- [ ] 测试用例添加
- [ ] `npm run test`通过

##### 详细描述

- 特性
- 关联issue
