### PR TITLE
fix-element-url

### DIFF
--- a/packages/wujie-core/src/utils.ts
+++ b/packages/wujie-core/src/utils.ts
@@ -171,6 +171,7 @@ export function fixElementCtrSrcOrHref(
   // patch setAttribute
   const rawElementSetAttribute = iframeWindow.Element.prototype.setAttribute;
   elementCtr.prototype.setAttribute = function (name: string, value: string): void {
+    value = value.startsWith("/") ? value : `/${value}`;
     let targetValue = value;
     if (name === attr) targetValue = getAbsolutePath(value, this.baseURI || "", true);
     rawElementSetAttribute.call(this, name, targetValue);
@@ -185,6 +186,7 @@ export function fixElementCtrSrcOrHref(
       return get.call(this);
     },
     set: function (href) {
+      href = href.startsWith("/") ? href : `/${href}`;
       set.call(this, getAbsolutePath(href, this.baseURI, true));
     },
   });


### PR DESCRIPTION
在获取资源绝对路径时，规范传入参数，使传入的url参数均为相对路径。

fix issue #413

<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [x] 文档更改
- [ ] 测试用例添加
- [x] `npm run test`通过

##### 详细描述

- 特性 在获取资源绝对路径时，规范传入参数，使传入的url参数均为相对路径。
- 关联issue #413
