### PR TITLE
fix: 修复在firefox下echarts、g6等canvas无法显示的问题(#428)

### DIFF
--- a/packages/wujie-core/src/iframe.ts
+++ b/packages/wujie-core/src/iframe.ts
@@ -784,7 +784,7 @@ export function iframeGenerator(
   appRoutePath: string
 ): HTMLIFrameElement {
   const iframe = window.document.createElement("iframe");
-  const attrsMerge = { src: mainHostPath, ...attrs, style: "display: none", name: sandbox.id, [WUJIE_DATA_FLAG]: "" };
+  const attrsMerge = { src: mainHostPath, style: "display: none", ...attrs, name: sandbox.id, [WUJIE_DATA_FLAG]: "" };
   setAttrsToElement(iframe, attrsMerge);
   window.document.body.appendChild(iframe);
 


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

-  [x] 提交符合commit规范
-  [x] `npm run test`通过

##### 详细描述

火狐浏览器的bug，如下
https://bugzilla.mozilla.org/show_bug.cgi?id=941146

在css容器设置为display:none下，对canvas.getContent().font赋值会报`NS_ERROR_FAILURE` 错误 ，导致canvas无法渲染成功

- 特性
- 关联issue 
   `issue #428`
