### PR TITLE
fix: 修复chrome85以下版本window.window报错问题

### DIFF
--- a/packages/wujie-core/src/proxy.ts
+++ b/packages/wujie-core/src/proxy.ts
@@ -53,7 +53,7 @@ export function proxyGenerator(
         return target.__WUJIE.proxyLocation;
       }
       // 判断自身
-      if (p === "self" || p === "window") {
+      if (p === "self" || (p === "window" && Object.getOwnPropertyDescriptor(window, "window").get)) {
         return target.__WUJIE.proxy;
       }
       // 不要绑定this


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [ ] 文档更改
- [ ] 测试用例添加
- [x] `npm run test`通过

##### 详细描述
解决在chrome 85以下版本，子应用执行window.window报错

- 特性
- 关联issue
#280
