### PR TITLE
fix: 适配子应用处理script标签

### DIFF
--- a/packages/wujie-core/src/common.ts
+++ b/packages/wujie-core/src/common.ts
@@ -191,6 +191,7 @@ export const windowRegWhiteList = [
 // 子应用的Document.prototype已经被改写了
 export const rawElementAppendChild = HTMLElement.prototype.appendChild;
 export const rawElementRemoveChild = HTMLElement.prototype.removeChild;
+export const rawElementContains = HTMLElement.prototype.contains;
 export const rawHeadInsertBefore = HTMLHeadElement.prototype.insertBefore;
 export const rawBodyInsertBefore = HTMLBodyElement.prototype.insertBefore;
 export const rawAddEventListener = Node.prototype.addEventListener;

--- a/packages/wujie-core/src/constant.ts
+++ b/packages/wujie-core/src/constant.ts
@@ -39,3 +39,4 @@ export const WUJIE_TIPS_NOT_SUPPORTED = "当前浏览器不支持无界，子应
 export const WUJIE_TIPS_SCRIPT_ERROR_REQUESTED = "脚本请求出现错误";
 export const WUJIE_TIPS_CSS_ERROR_REQUESTED = "样式请求出现错误";
 export const WUJIE_TIPS_REPEAT_RENDER = "无界组件短时间重复渲染了两次，可能存在性能问题请检查代码";
+export const WUJIE_TIPS_NO_SCRIPT = "目标Script尚未准备好或已经被移除";

--- a/packages/wujie-core/src/iframe.ts
+++ b/packages/wujie-core/src/iframe.ts
@@ -13,6 +13,8 @@ import {
   getCurUrl,
   getAbsolutePath,
   setAttrsToElement,
+  setTagToScript,
+  getTagFromScript,
 } from "./utils";
 import {
   documentProxyProperties,
@@ -48,6 +50,9 @@ declare global {
 
     // iframe内原生的createTextNode
     __WUJIE_RAW_DOCUMENT_CREATE_TEXT_NODE__: typeof Document.prototype.createTextNode;
+
+    // iframe内原生的head
+    __WUJIE_RAW_DOCUMENT_HEAD__: typeof Document.prototype.head;
 
     // 原生的querySelector
     __WUJIE_RAW_DOCUMENT_QUERY_SELECTOR_ALL__: typeof Document.prototype.querySelectorAll;
@@ -604,7 +609,7 @@ function initIframeDom(iframeWindow: Window, wujie: WuJie, mainHostPath: string,
   iframeDocument.documentElement
     ? iframeDocument.replaceChild(newDocumentElement, iframeDocument.documentElement)
     : iframeDocument.appendChild(newDocumentElement);
-
+  iframeWindow.__WUJIE_RAW_DOCUMENT_HEAD__ = iframeDocument.head;
   initBase(iframeWindow, wujie.url);
   patchIframeHistory(iframeWindow, appHostPath, mainHostPath);
   patchIframeEvents(iframeWindow);
@@ -744,6 +749,9 @@ export function insertScriptToIframe(
   if (/^<!DOCTYPE html/i.test(code)) {
     error(WUJIE_TIPS_SCRIPT_ERROR_REQUESTED, scriptResult);
     return !async && container.appendChild(nextScriptElement);
+  }
+  if (rawElement) {
+    setTagToScript(scriptElement, getTagFromScript(rawElement));
   }
   container.appendChild(scriptElement);
 

--- a/packages/wujie-core/src/utils.ts
+++ b/packages/wujie-core/src/utils.ts
@@ -286,6 +286,24 @@ export function execHooks(plugins: Array<plugin>, hookName: string, ...args: Arr
   }
 }
 
+export function isScriptElement(element: HTMLElement): boolean {
+  return element.tagName?.toUpperCase() === "SCRIPT";
+}
+
+export function setTagToScript(element: HTMLScriptElement, tag?: string): void {
+  if (isScriptElement(element)) {
+    const scriptTag = tag || `${new Date().valueOf()}`;
+    element.setAttribute("wujie", scriptTag);
+  }
+}
+
+export function getTagFromScript(element: HTMLScriptElement): string | null {
+  if (isScriptElement(element)) {
+    return element.getAttribute("wujie");
+  }
+  return null;
+}
+
 // 合并缓存
 export function mergeOptions(options: cacheOptions, cacheOptions: cacheOptions) {
   return {


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [ ] 测试用例添加
- [x] `npm run test`通过

##### 详细描述
`wujie`重写了子应用`ShadowRoot`的`head.appendChild`方法，将子应用插入的`script`转移到了同域`Iframe`内的`head`。然而`contains`和`removeChild`方法依然指向的是`ShadowRoot`，这导致子应用在插入`script`后无法通过`contains`判断该`script`的存在，也无法通过`document.head.removeChild`将其移除。

此PR调整了`ShadowRoot`的`head.contains`、`contains`、`head.removeChild`这三个方法，尝试适配子应用对`script`的处理。适配后效果如下：
```
  const script = document.createElement('script')
  script.type = 'text/javascript'
  script.async = true
  script.src = 'test.js'
  document.head.appendChild(script)

  console.log(document.contains(script)) // false, [wujie warn]: 目标Script尚未准备好或已经被移除 <script wujie='1679239314179'/>
  console.log(document.head.contains(script)) // false, [wujie warn]: 目标Script尚未准备好或已经被移除 <script wujie='1679239314179'/>

  // 等待wujie的script加载完成
  setTimeout(() => {
    console.log(document.contains(script)) // true
    console.log(document.head.contains(script)) // true
    document.head.removeChild(script) // succeed
  }, 2000)
```

- 特性
- 关联issue
#452 