### PR TITLE
refactor: 优化 stopIframeLoading，让逻辑更清晰，增加可读性

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ coverage
 # Log files
 .pnpm-debug.log*
 cache
+.idea


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [ ] 文档更改
- [ ] 测试用例添加
- [x] `npm run test`通过

##### 详细描述

在阅读源码时，看到 `iframeGenerator`  只做了 2 个事情：
+ `patchIframeVariable`
+ `stopIframeLoading`

但实际上，更主要的部分，是在  `initIframeDom` 函数中，这个函数写在 `stopIframeLoading`，`stopIframeLoading` 实际作用跟函数名称，应该把 `initIframeDom` 放到外边

