### PR TITLE
fix: 修复script脚本属性丢失的问题

### DIFF
--- a/packages/wujie-core/src/effect.ts
+++ b/packages/wujie-core/src/effect.ts
@@ -34,7 +34,7 @@ import {
   WUJIE_TIPS_REPEAT_RENDER,
   WUJIE_TIPS_NO_SCRIPT,
 } from "./constant";
-import { ScriptObject } from "./template";
+import { ScriptObject, getScriptAttrs } from "./template";
 
 function patchCustomEvent(
   e: CustomEvent,
@@ -274,6 +274,7 @@ function rewriteAppendOrInsertChild(opts: {
               crossorigin: crossOrigin !== null,
               crossoriginType: crossOrigin || "",
               ignore: isMatchUrl(src, getEffectLoaders("jsIgnores", plugins)),
+              attrs: getScriptAttrs(element.outerHTML),
             } as ScriptObject;
             getExternalScripts([scriptOptions], fetch, lifecycles.loadError, fiber).forEach((scriptResult) => {
               dynamicScriptExecStack = dynamicScriptExecStack.then(() =>
@@ -303,9 +304,17 @@ function rewriteAppendOrInsertChild(opts: {
             sandbox.execQueue.push(() =>
               fiber
                 ? requestIdleCallback(() => {
-                    insertScriptToIframe({ src: null, content: text }, sandbox.iframe.contentWindow, element);
+                    insertScriptToIframe(
+                      { src: null, content: text, attrs: getScriptAttrs(element.outerHTML) },
+                      sandbox.iframe.contentWindow,
+                      element
+                    );
                   })
-                : insertScriptToIframe({ src: null, content: text }, sandbox.iframe.contentWindow, element)
+                : insertScriptToIframe(
+                    { src: null, content: text, attrs: getScriptAttrs(element.outerHTML) },
+                    sandbox.iframe.contentWindow,
+                    element
+                  )
             );
             if (!execQueueLength) sandbox.execQueue.shift()();
           }

--- a/packages/wujie-core/src/index.ts
+++ b/packages/wujie-core/src/index.ts
@@ -1,5 +1,5 @@
 import importHTML, { processCssLoader } from "./entry";
-import { StyleObject } from "./template";
+import { StyleObject, ScriptAttributes } from "./template";
 import WuJie, { lifecycle } from "./sandbox";
 import { defineWujieWebComponent, addLoading } from "./shadow";
 import { processAppForHrefJump } from "./sync";
@@ -22,6 +22,8 @@ export interface ScriptObjectLoader {
   crossorigin?: boolean;
   /** 脚本crossorigin的类型 */
   crossoriginType?: "anonymous" | "use-credentials" | "";
+  /** 脚本原始属性 */
+  attrs?: ScriptAttributes;
   /** 内联script的代码 */
   content?: string;
   /** 执行回调钩子 */


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [ ] 文档更改
- [ ] 测试用例添加
- [x] `npm run test`通过

##### 详细描述

- 特性
不管是外联脚本还是动态脚本，无界会将这些脚本转化为内联脚本，并且在这个过程中抛弃了原始脚本上的属性，比如id、data-xxx等等，本次pr会将原始属性保留到内联脚本中，比如：
```javascript
<script id="myscript" data-message="hello" src="xxxxxxx"></script>
```
会最终转化成：

```javascript
<script id="myscript" data-message="hello"> yyyyyyy </script>
```

可以通过 document.getElementByid(myscript) 或者 document.querySelector('#myscript')获取转化后的脚本


- 关联issue
 #464 #374

