### PR TITLE
fix(iframe): 修复 handler 为 undefined 时添加到 handlerCallbackMap 报错

### DIFF
--- a/packages/wujie-core/src/iframe.ts
+++ b/packages/wujie-core/src/iframe.ts
@@ -390,7 +390,7 @@ function patchDocumentEffect(iframeWindow: Window): void {
     let callback = handlerCallbackMap.get(handler);
     const typeList = handlerTypeMap.get(handler);
     // 设置 handlerCallbackMap
-    if (!callback) {
+    if (!callback && handler) {
       callback = typeof handler === "function" ? handler.bind(this) : handler;
       handlerCallbackMap.set(handler, callback);
     }


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [x] `npm run test`通过

##### 详细描述

当我使用第三方库时，发现它内部未传递 `addEventListener` 事件处理函数，导致报错，我在 ifrane.ts 中对它进行了为空判断

##### 错误示例

![image](https://user-images.githubusercontent.com/55641773/228754180-3394a183-b098-4d40-9717-e5db770ec0b0.png)
