### PR TITLE
fix: 修复子应用嵌套页面空白问题

### DIFF
--- a/packages/wujie-core/src/iframe.ts
+++ b/packages/wujie-core/src/iframe.ts
@@ -606,10 +606,10 @@ function initIframeDom(iframeWindow: Window, wujie: WuJie, mainHostPath: string,
     ? iframeDocument.replaceChild(newDocumentElement, iframeDocument.documentElement)
     : iframeDocument.appendChild(newDocumentElement);
   iframeWindow.__WUJIE_RAW_DOCUMENT_HEAD__ = iframeDocument.head;
-  iframeWindow.__WUJIE_RAW_DOCUMENT_QUERY_SELECTOR__ = iframeDocument.querySelector;
-  iframeWindow.__WUJIE_RAW_DOCUMENT_QUERY_SELECTOR_ALL__ = iframeDocument.querySelectorAll;
-  iframeWindow.__WUJIE_RAW_DOCUMENT_CREATE_ELEMENT__ = iframeDocument.createElement;
-  iframeWindow.__WUJIE_RAW_DOCUMENT_CREATE_TEXT_NODE__ = iframeDocument.createTextNode;
+  iframeWindow.__WUJIE_RAW_DOCUMENT_QUERY_SELECTOR__ = iframeWindow.Document.prototype.querySelector;
+  iframeWindow.__WUJIE_RAW_DOCUMENT_QUERY_SELECTOR_ALL__ = iframeWindow.Document.prototype.querySelectorAll;
+  iframeWindow.__WUJIE_RAW_DOCUMENT_CREATE_ELEMENT__ = iframeWindow.Document.prototype.createElement;
+  iframeWindow.__WUJIE_RAW_DOCUMENT_CREATE_TEXT_NODE__ = iframeWindow.Document.prototype.createTextNode;
   initBase(iframeWindow, wujie.url);
   patchIframeHistory(iframeWindow, appHostPath, mainHostPath);
   patchIframeEvents(iframeWindow);

--- a/packages/wujie-core/src/proxy.ts
+++ b/packages/wujie-core/src/proxy.ts
@@ -131,7 +131,10 @@ export function proxyGenerator(
               }
               return (
                 target.call(shadowRoot, `[id="${args[0]}"]`) ||
-                iframe.contentWindow.__WUJIE_RAW_DOCUMENT_QUERY_SELECTOR__(`#${args[0]}`)
+                iframe.contentWindow.__WUJIE_RAW_DOCUMENT_QUERY_SELECTOR__.call(
+                  iframe.contentWindow.document,
+                  `#${args[0]}`
+                )
               );
             },
           });
@@ -149,7 +152,9 @@ export function proxyGenerator(
               // 二选一，优先shadowDom，除非采用array合并，排除base，防止对router造成影响
               return (
                 target.apply(shadowRoot, args) ||
-                (args[0] === "base" ? null : iframe.contentWindow[rawPropMap[propKey]](args[0]))
+                (args[0] === "base"
+                  ? null
+                  : iframe.contentWindow[rawPropMap[propKey]].call(iframe.contentWindow.document, args[0]))
               );
             },
           });

--- a/packages/wujie-core/src/template.ts
+++ b/packages/wujie-core/src/template.ts
@@ -88,20 +88,20 @@ function isValidJavaScriptType(type) {
 }
 
 /**
- * 解析 script 标签的属性
+ * 解析标签的属性
  * @param scriptOuterHTML script 标签的 outerHTML
  * @returns 返回一个对象，包含 script 标签的所有属性
  */
-export function parseScriptAttributes(scriptOuterHTML) {
-  const pattern = /<script\s+([^>]*)>/i;
-  const matches = pattern.exec(scriptOuterHTML);
+export function parseTagAttributes(TagOuterHTML) {
+  const pattern = /<[-\w]+\s+([^>]*)>/i;
+  const matches = pattern.exec(TagOuterHTML);
 
   if (!matches) {
     return {};
   }
 
   const attributesString = matches[1];
-  const attributesPattern = /(\w+)\s*=\s*(['"])(.*?)\2/g;
+  const attributesPattern = /([^\s=]+)\s*=\s*(['"])(.*?)\2/g;
   const attributesObject = {};
 
   let attributeMatches;
@@ -251,14 +251,14 @@ export default function processTpl(tpl: String, baseURI: String, postProcessTemp
                   module: isModuleScript,
                   crossorigin: !!isCrossOriginScript,
                   crossoriginType: crossOriginType,
-                  attrs: parseScriptAttributes(match),
+                  attrs: parseTagAttributes(match),
                 }
               : {
                   src: matchedScriptSrc,
                   module: isModuleScript,
                   crossorigin: !!isCrossOriginScript,
                   crossoriginType: crossOriginType,
-                  attrs: parseScriptAttributes(match),
+                  attrs: parseTagAttributes(match),
                 }
           );
           return genScriptReplaceSymbol(
@@ -290,7 +290,7 @@ export default function processTpl(tpl: String, baseURI: String, postProcessTemp
             module: isModuleScript,
             crossorigin: !!isCrossOriginScript,
             crossoriginType: crossOriginType,
-            attrs: parseScriptAttributes(match),
+            attrs: parseTagAttributes(match),
           });
         }
 


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [ ] 文档更改
- [ ] 测试用例添加
- [x] `npm run test`通过

##### 详细描述

- 特性
修复了子应用空白的问题，该问题是因为代码  iframeWindow.__WUJIE_RAW_DOCUMENT_QUERY_SELECTOR__ 绑定了iframeWindow.document 导致在嵌套的 子应用内使用 call 无效
修复了link的 id 丢失的问题 

- 关联issue

#487  #485 
