### PR TITLE
fix(iframe): 修复 handler 为 undefined 时执行 addEventListener 错误

### DIFF
--- a/packages/wujie-core/src/iframe.ts
+++ b/packages/wujie-core/src/iframe.ts
@@ -186,7 +186,6 @@ function patchIframeHistory(iframeWindow: Window, appHostPath: string, mainHostP
 /**
  * 动态的修改iframe的base地址
  * @param iframeWindow
- * @param url
  * @param appHostPath
  * @param mainHostPath
  */
@@ -387,10 +386,11 @@ function patchDocumentEffect(iframeWindow: Window): void {
     handler: EventListenerOrEventListenerObject,
     options?: boolean | AddEventListenerOptions
   ): void {
+    if (!handler) return;
     let callback = handlerCallbackMap.get(handler);
     const typeList = handlerTypeMap.get(handler);
     // 设置 handlerCallbackMap
-    if (!callback && handler) {
+    if (!callback) {
       callback = typeof handler === "function" ? handler.bind(this) : handler;
       handlerCallbackMap.set(handler, callback);
     }
@@ -597,6 +597,9 @@ export function initBase(iframeWindow: Window, url: string): void {
 /**
  * 初始化iframe的dom结构
  * @param iframeWindow
+ * @param wujie
+ * @param mainHostPath
+ * @param appHostPath
  */
 function initIframeDom(iframeWindow: Window, wujie: WuJie, mainHostPath: string, appHostPath: string): void {
   const iframeDocument = iframeWindow.document;
@@ -631,7 +634,7 @@ function stopIframeLoading(iframeWindow: Window) {
   return new Promise<void>((resolve) => {
     function loop() {
       setTimeout(() => {
-        let newDoc = null;
+        let newDoc;
         try {
           newDoc = iframeWindow.document;
         } catch (err) {
@@ -766,7 +769,8 @@ export function insertScriptToIframe(
 /**
  * 加载iframe替换子应用
  * @param src 地址
- * @param shadowRoot
+ * @param element
+ * @param degradeAttrs
  */
 export function renderIframeReplaceApp(
   src: string,


### PR DESCRIPTION
## 详细描述

在 #483 中，未进行后续的handler有效判断，导致后续执行错误，当handler未传递时，应停止执行后续的操作。

- 特性
- 关联issue #483 
