### PR TITLE
修复 react17 & vue3 多次推入history的问题

### DIFF
--- a/examples/main-react/src/App.js
+++ b/examples/main-react/src/App.js
@@ -32,16 +32,6 @@ function Nav() {
   const [viteFlag, setViteFlag] = useState(location.pathname.includes("vite-sub"));
   const degrade = window.Proxy
 
-  // 在 xxx-sub 路由下子应用将激活路由同步给主应用，主应用跳转对应路由高亮菜单栏
-  bus.$on("sub-route-change", (name, path) => {
-    const mainName = `${name}-sub`;
-    const mainPath = `/${name}-sub${path}`;
-    const currentPath = window.location.hash.replace("#", "")
-    if(currentPath.includes(mainName) && currentPath !== mainPath) {
-      navigation(mainPath);
-    }
-  });
-
 
   const handleFlag = (name) => {
     switch (name) {

--- a/examples/main-vue/src/main.js
+++ b/examples/main-vue/src/main.js
@@ -27,17 +27,6 @@ Vue.config.productionTip = false;
 
 bus.$on("click", (msg) => window.alert(msg));
 
-// 在 xxx-sub 路由下子应用将激活路由同步给主应用，主应用跳转对应路由高亮菜单栏
-bus.$on("sub-route-change", (name, path) => {
-  const mainName = `${name}-sub`;
-  const mainPath = `/${name}-sub${path}`;
-  const currentName = router.currentRoute.name;
-  const currentPath = router.currentRoute.path;
-  if (mainName === currentName && mainPath !== currentPath) {
-    router.push({ path: mainPath });
-  }
-});
-
 const degrade = window.localStorage.getItem("degrade") === "true" || !window.Proxy || !window.CustomElementRegistry;
 const props = {
   jump: (name) => {

--- a/examples/react16/src/App.js
+++ b/examples/react16/src/App.js
@@ -38,12 +38,6 @@ const Home = () => (
 );
 
 export default function App() {
-  // 在 react16-sub 路由下主动告知主应用路由跳转，主应用也跳到相应路由高亮菜单栏
-  const location = useLocation()
-  useEffect(() => {
-    window.$wujie?.bus.$emit('sub-route-change', "react16", location.pathname)
-  }, [location])
-
   return (
     <div>
       <nav>

--- a/examples/react17/src/App.js
+++ b/examples/react17/src/App.js
@@ -40,17 +40,11 @@ const Home = () => (
 
 function Nav() {
   const history = useHistory();
-  const routerJump = path =>  history.push(path)
+  const routerJump = path =>  history.replace(path)
   // 主应用告诉子应用跳转路由
   useEffect(() => {
     window.$wujie?.bus.$on("react17-router-change", routerJump);
   }, [])
-
-  // 在 react17-sub 路由下主动告知主应用路由跳转，主应用也跳到相应路由高亮菜单栏
-  const location = useLocation()
-  useEffect(() => {
-    window.$wujie?.bus.$emit('sub-route-change', "react17", location.pathname)
-  }, [location])
 
   return (
     <nav>

--- a/examples/vite/src/App.vue
+++ b/examples/vite/src/App.vue
@@ -10,11 +10,5 @@
 
 <script>
 export default {
-  watch: {
-    // 在 vite-sub 路由下主动告知主应用路由跳转，主应用也跳到相应路由高亮菜单栏
-    $route() {
-      window.$wujie?.bus.$emit("sub-route-change", "vite", this.$route.path);
-    },
-  },
 };
 </script>

--- a/examples/vue2/src/App.vue
+++ b/examples/vue2/src/App.vue
@@ -10,11 +10,5 @@
 
 <script>
 export default {
-  watch: {
-    // 在 vue2-sub 路由下主动告知主应用路由跳转，主应用也跳到相应路由高亮菜单栏
-    $route() {
-      window.$wujie?.bus.$emit("sub-route-change", "vue2", this.$route.path);
-    },
-  },
 };
 </script>

--- a/examples/vue3/src/App.vue
+++ b/examples/vue3/src/App.vue
@@ -9,10 +9,7 @@
 
 <script>
 export default {
-  watch: {
-  },
   mounted() {
-    // 防止
     window.$wujie?.bus.$on("vue3-router-change", (path) => this.$router.replace(path));
   },
 };

--- a/examples/vue3/src/App.vue
+++ b/examples/vue3/src/App.vue
@@ -10,13 +10,10 @@
 <script>
 export default {
   watch: {
-    // 在 vue3-sub 路由下主动告知主应用路由跳转，主应用也跳到相应路由高亮菜单栏
-    $route() {
-      window.$wujie?.bus.$emit("sub-route-change", "vue3", this.$route.path);
-    },
   },
   mounted() {
-    window.$wujie?.bus.$on("vue3-router-change", (path) => this.$router.push(path));
+    // 防止
+    window.$wujie?.bus.$on("vue3-router-change", (path) => this.$router.replace(path));
   },
 };
 </script>


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范

##### 详细描述

发现在上述两个项目下，每次路由跳转都会推入两次history，导致回退异常
现象：需要连续点击两次浏览器后退按钮url地址才发生一次变化（但内容已经发生变化了两次）就会造成url和内容不同步
原demo的解决方案是以基座路由 !== 当前子应用路由时就强制在基座中 push一次history，随可以解决上述问题，但浏览器回退按钮，只能反复在上一级路由和当前路由中切换，无法继续回退
如（每条相当于一次触发回退按钮）：
1、A > b(head) > c
2、A > b > c (head)
3、 A > b(head) > c
4、A > b > c (head)
解决方法： 在v3项目中的
window.$wujie?.bus.$on("vue3-router-change", (path) => this.$router.**push**(path));
改成： this.$router.**replace**(path));
在r17项目中的
const routerJump = path => history.**push**(path)
改成：
const routerJump = path => history.**replace**(path)

同时删掉了基座的sub-route-change监听，没用了
