### PR TITLE
重建模式的子应用，不应该清除全局缓存的config

### DIFF
--- a/packages/wujie-core/src/index.ts
+++ b/packages/wujie-core/src/index.ts
@@ -250,7 +250,7 @@ export async function startApp(startOptions: startOptions): Promise<Function | v
       return sandbox.destroy;
     } else {
       // 没有渲染函数
-      sandbox.destroy();
+      sandbox.destroy(false);
     }
   }
 

--- a/packages/wujie-core/src/index.ts
+++ b/packages/wujie-core/src/index.ts
@@ -250,7 +250,7 @@ export async function startApp(startOptions: startOptions): Promise<Function | v
       return sandbox.destroy;
     } else {
       // 没有渲染函数
-      sandbox.destroy(false);
+      sandbox.destroy(true);
     }
   }
 

--- a/packages/wujie-core/src/sandbox.ts
+++ b/packages/wujie-core/src/sandbox.ts
@@ -382,7 +382,7 @@ export default class Wujie {
   }
 
   /** 销毁子应用 */
-  public destroy(clearConfig?: boolean) {
+  public destroy(disClear?: boolean) {
     this.bus.$clear();
     this.shadowRoot = null;
     this.proxy = null;
@@ -417,7 +417,7 @@ export default class Wujie {
     if (this.iframe) {
       this.iframe.parentNode?.removeChild(this.iframe);
     }
-    if (clearConfig) {
+    if (!disClear) {
       deleteWujieById(this.id);
     }
   }

--- a/packages/wujie-core/src/sandbox.ts
+++ b/packages/wujie-core/src/sandbox.ts
@@ -382,7 +382,7 @@ export default class Wujie {
   }
 
   /** 销毁子应用 */
-  public destroy() {
+  public destroy(clearConfig?: boolean) {
     this.bus.$clear();
     this.shadowRoot = null;
     this.proxy = null;
@@ -417,7 +417,9 @@ export default class Wujie {
     if (this.iframe) {
       this.iframe.parentNode?.removeChild(this.iframe);
     }
-    deleteWujieById(this.id);
+    if (clearConfig) {
+      deleteWujieById(this.id);
+    }
   }
 
   /** 当子应用再次激活后，只运行mount函数，样式需要重新恢复 */


### PR DESCRIPTION
- [x] 提交符合commit规范

##### 详细描述
修复使用重建模式的子应用，使用setupApps添加配置，在切换子应用是会被清除全局缓存配置的问题。该问题导致再次加载重建模式的应用，setupApps中的配置均丢失，导致子系统异常。

