### PR TITLE
fix(proxy): protect the program when querySelectorAll throws an excep…

### DIFF
--- a/packages/wujie-core/src/proxy.ts
+++ b/packages/wujie-core/src/proxy.ts
@@ -118,7 +118,19 @@ export function proxyGenerator(
               }
               if (propKey === "getElementsByClassName") arg = "." + arg;
               if (propKey === "getElementsByName") arg = `[name="${arg}"]`;
-              return querySelectorAll.call(shadowRoot, arg);
+
+              // FIXME: This string must be a valid CSS selector string; if it's not, a SyntaxError exception is thrown;
+              // so we should ensure that the program can execute normally in case of exceptions.
+              // reference: https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelectorAll
+
+              let res: NodeList[] | [];
+              try {
+                res = querySelectorAll.call(shadowRoot, arg);
+              } catch (error) {
+                res = [];
+              }
+
+              return res;
             },
           });
         }


### PR DESCRIPTION
- [x] 提交符合commit规范
- [x] `npm run test`通过

##### 详细描述

`wujie` 对子应用中的 `getElementsByTagName`, `getElementsByClassName`, `getElementsByName` 进行了拦截，并在某些条件下采用了 `querySelectorAll`  进行替代，根据 [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelectorAll) 上的描述，如果传递给 `querySelectorAll` 是一个非法的字符，那么 `querySelectorAll` 就会抛出异常阻止程序的执行

这里需要对程序的运行做一层保护，应对外部传递给 `querySelectorAll` 的非法参数的情况。

举个场景，比如在使用 [YouTube Player](https://developers.google.com/youtube/iframe_api_reference?hl=zh-cn) 的时候，会出现 `yt:player` 的情况

![demo](https://github.com/Tencent/wujie/assets/40482155/1fbb15da-17ab-43f8-832a-6c6a8f7ee68a)

这个时候如果不对 `querySelectorAll` 的执行过程进行保护，那么就会影响外部程序的执行

