### PR TITLE
fix: 兼容子应用定义不可修改的全局函数

### DIFF
--- a/packages/wujie-core/src/proxy.ts
+++ b/packages/wujie-core/src/proxy.ts
@@ -61,6 +61,11 @@ export function proxyGenerator(
       if (p === "__WUJIE_RAW_DOCUMENT_QUERY_SELECTOR__" || p === "__WUJIE_RAW_DOCUMENT_QUERY_SELECTOR_ALL__") {
         return target[p];
       }
+      // https://262.ecma-international.org/8.0/#sec-proxy-object-internal-methods-and-internal-slots-get-p-receiver
+      const descriptor = Object.getOwnPropertyDescriptor(target, p);
+      if (descriptor?.configurable === false && descriptor?.writable === false) {
+        return target[p];
+      }
       // 修正this指针指向
       return getTargetValue(target, p);
     },

--- a/packages/wujie-core/src/utils.ts
+++ b/packages/wujie-core/src/utils.ts
@@ -94,11 +94,6 @@ export function getTargetValue(target: any, p: any): any {
     return setFnCacheMap.get(value);
   }
   if (isCallable(value) && !isBoundedFunction(value) && !isConstructable(value)) {
-    // https://262.ecma-international.org/8.0/#sec-proxy-object-internal-methods-and-internal-slots-get-p-receiver
-    const descriptor = Object.getOwnPropertyDescriptor(target, p);
-    if (descriptor?.configurable === false && descriptor?.writable === false) {
-      return value;
-    }
     const boundValue = Function.prototype.bind.call(value, target);
     setFnCacheMap.set(value, boundValue);
 

--- a/packages/wujie-core/src/utils.ts
+++ b/packages/wujie-core/src/utils.ts
@@ -94,6 +94,11 @@ export function getTargetValue(target: any, p: any): any {
     return setFnCacheMap.get(value);
   }
   if (isCallable(value) && !isBoundedFunction(value) && !isConstructable(value)) {
+    // https://262.ecma-international.org/8.0/#sec-proxy-object-internal-methods-and-internal-slots-get-p-receiver
+    const descriptor = Object.getOwnPropertyDescriptor(target, p);
+    if (descriptor?.configurable === false && descriptor?.writable === false) {
+      return value;
+    }
     const boundValue = Function.prototype.bind.call(value, target);
     setFnCacheMap.set(value, boundValue);
 


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [x] `npm run test`通过

##### 详细描述
子应用往全局定义一个不可写且不可配置的数据属性，当这个属性为函数时，在`wujie`内会调用失败，并报错：
```
    Object.defineProperty(window, 'testPro', {
      configurable: false,
      writable: false,
      value: function() {
        return 'testValue'
      }
    })
    console.log(window.testPro()) // TypeError: 'get' on proxy: property 'testPro' is a read-only and non-configurable data property on the proxy target but the proxy did not return its actual value
```
这是因为子应用通过`wujie`的`proxyWindow`读取这个属性时，`wujie`发现是个函数，会尝试改变其`this`指向并返回新的执行结果。然而对于不可写且不可配置的数据属性，ES要求返回原值：
https://262.ecma-international.org/8.0/#sec-proxy-object-internal-methods-and-internal-slots-get-p-receiver
> NOTE [[Get]] for proxy objects enforces the following invariants:
> - The value reported for a property must be the same as the value of the corresponding target object property if the target object property is a non-writable, non-configurable own data property.

兼容后：
```
    Object.defineProperty(window, 'testPro', {
      configurable: false,
      writable: false,
      value: function() {
        return 'testValue'
      }
    })
    console.log(window.testPro()) // testValue
```


- 特性
- 关联issue
