### PR TITLE
fix: 当子应用location.replace到其他域名时，改为渲染到另一个iframe中

### DIFF
--- a/packages/wujie-core/src/proxy.ts
+++ b/packages/wujie-core/src/proxy.ts
@@ -13,23 +13,37 @@ import {
   stopMainAppRun,
 } from "./utils";
 
+function generateUrl(url: string, appHostPath: string) {
+  let newUrl = url;
+  if (!/^http/.test(url)) {
+    let hrefElement = anchorElementGenerator(url);
+    newUrl = appHostPath + hrefElement.pathname + hrefElement.search + hrefElement.hash;
+    hrefElement = null;
+  }
+  return newUrl;
+}
+
+function renderInIframe(iframe: HTMLIFrameElement, url: string) {
+  const { shadowRoot, id, degrade, degradeAttrs } = iframe.contentWindow.__WUJIE;
+  if (degrade) {
+    renderIframeReplaceApp(window.decodeURIComponent(url), getDegradeIframe(id).parentElement, degradeAttrs);
+    return;
+  }
+  renderIframeReplaceApp(url, shadowRoot.host.parentElement, degradeAttrs);
+}
+
 /**
  * location href 的set劫持操作
  */
 function locationHrefSet(iframe: HTMLIFrameElement, value: string, appHostPath: string): boolean {
-  const { shadowRoot, id, degrade, document, degradeAttrs } = iframe.contentWindow.__WUJIE;
-  let url = value;
-  if (!/^http/.test(url)) {
-    let hrefElement = anchorElementGenerator(url);
-    url = appHostPath + hrefElement.pathname + hrefElement.search + hrefElement.hash;
-    hrefElement = null;
-  }
+  const { id, degrade, document } = iframe.contentWindow.__WUJIE;
   iframe.contentWindow.__WUJIE.hrefFlag = true;
   if (degrade) {
     const iframeBody = rawDocumentQuerySelector.call(iframe.contentDocument, "body");
     renderElementToContainer(document.documentElement, iframeBody);
-    renderIframeReplaceApp(window.decodeURIComponent(url), getDegradeIframe(id).parentElement, degradeAttrs);
-  } else renderIframeReplaceApp(url, shadowRoot.host.parentElement, degradeAttrs);
+  }
+  const url = generateUrl(value, appHostPath);
+  renderInIframe(iframe, url);
   pushUrlToWindow(id, url);
   return true;
 }
@@ -220,7 +234,11 @@ export function proxyGenerator(
         if (propKey === "replace") {
           return new Proxy(location[propKey], {
             apply(replace, _ctx, args) {
-              return replace.call(location, args[0]?.replace(appHostPath, mainHostPath));
+              if (args[0]?.includes?.(appHostPath)) {
+                return replace.call(location, args[0]?.replace(appHostPath, mainHostPath));
+              }
+              const url = generateUrl(args[0], appHostPath);
+              return renderInIframe(iframe, url);
             },
           });
         }


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [x] `npm run test`通过

##### 详细描述
目前，当子应用通过`location.replace`跳转其他域名地址，新地址下的内容会在主应用的同域`iframe`中加载，创建的节点也会插到同域`iframe`中，`shadowDom`中则依然是跳转前的子应用内容，无法正常交互。

此提交针对这种场景，将子应用自动转到一个新的`iframe`中加载，确保子应用显示及交互正常。


- 特性
- 关联issue
