### PR TITLE
fix: 适配获取shadowDom中html的clientHeight

### DIFF
--- a/packages/wujie-core/src/shadow.ts
+++ b/packages/wujie-core/src/shadow.ts
@@ -206,6 +206,20 @@ function renderTemplateToHtml(iframeWindow: Window, template: string): HTMLHtmlE
   return html;
 }
 
+function adaptedShadowRootHtml(shadowRoot: ShadowRoot, iframeWindow: Window) {
+  Object.defineProperty(shadowRoot.firstChild, "parentNode", {
+    enumerable: true,
+    configurable: true,
+    get: () => iframeWindow.document,
+  });
+  // https://www.w3.org/TR/2016/WD-cssom-view-1-20160317/#dom-element-clientheight
+  Object.defineProperty(shadowRoot.firstChild, "clientHeight", {
+    enumerable: true,
+    configurable: true,
+    get: () => iframeWindow.parent?.document.documentElement.clientHeight,
+  });
+}
+
 /**
  * 将template渲染到shadowRoot
  */
@@ -224,14 +238,7 @@ export async function renderTemplateToShadowRoot(
   processedHtml.insertBefore(shade, processedHtml.firstChild);
   shadowRoot.head = shadowRoot.querySelector("head");
   shadowRoot.body = shadowRoot.querySelector("body");
-
-  // 修复 html parentNode
-  Object.defineProperty(shadowRoot.firstChild, "parentNode", {
-    enumerable: true,
-    configurable: true,
-    get: () => iframeWindow.document,
-  });
-
+  adaptedShadowRootHtml(shadowRoot, iframeWindow);
   patchRenderEffect(shadowRoot, iframeWindow.__WUJIE.id, false);
 }
 


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [ ] 文档更改
- [ ] 测试用例添加
- [x] `npm run test`通过

##### 详细描述
通过`clientHeight`获取元素高度有个特例：
对于`html`节点，会拿到窗口高度（viewport height）：https://www.w3.org/TR/2016/WD-cssom-view-1-20160317/#dom-element-clientheight

但在`shadowDom`中，子应用`html`的`clientHeight`拿到的是`html`节点高度。
```
document.documentElement.clientHeight // html height
```
非降级模式下，子应用弹窗可以溢出到全局，但当子应用内的悬浮提示定位依赖这个属性时，就会导致定位不准确。
（我这边出问题的场景是，子应用的弹窗内，表单校验提示的悬浮气泡定位不准）
排查发现是气泡的定位代码依赖了`jQuery`获取`window`高度的写法：
```
jQuery(window).height()
```
`jQuery`对应的内部实现为：
```
if ( isWindow( elem ) ) {
    return funcName.indexOf( "outer" ) === 0 ?
        elem[ "inner" + name ] :
        elem.document.documentElement[ "client" + name ];
}
```
拿到了`html`的高度从而导致气泡错位。
此PR针对该场景，处理了`shadowDom`内`html`的`clientHeight`属性，使其拿到外层`html`的`clientHeight`。
对于嵌套场景，会继续传递，拿到最外层的`html`的`clientHeight`。
对于降级场景，因弹窗不会溢出到全局，故无需处理。


- 特性
- 关联issue
