### PR TITLE
fix: 修复wujie子应用无法监听error事件

### DIFF
--- a/packages/wujie-core/src/common.ts
+++ b/packages/wujie-core/src/common.ts
@@ -166,6 +166,7 @@ export const appWindowAddEventListenerEvents = [
   "beforeunload",
   "unload",
   "message",
+  "error",
 ];
 
 // 子应用window.onXXX需要挂载到iframe沙箱上的事件


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [ ] 提交符合commit规范
- [ ] 文档更改
- [ ] 测试用例添加
- [ ] `npm run test`通过

##### 详细描述

wujie子应用中使用`window.addEventListener('error', fn)`无法进入监听函数，故增加此行代码
