### PR TITLE
fix: 子应用使用 getElementById args为Object时报错，应返回null;

### DIFF
--- a/packages/wujie-core/src/proxy.ts
+++ b/packages/wujie-core/src/proxy.ts
@@ -146,6 +146,8 @@ export function proxyGenerator(
               if (ctx !== iframe.contentDocument) {
                 return ctx[propKey]?.apply(ctx, args);
               }
+              // 部分组件库会利用 args 为 HtmlElement 时返回null，判断插入位置
+              if (typeof args[0] !== "string") return null;
               return (
                 target.call(shadowRoot, `[id="${args[0]}"]`) ||
                 iframe.contentWindow.__WUJIE_RAW_DOCUMENT_QUERY_SELECTOR__.call(


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [ ] 文档更改
- [ ] 测试用例添加
- [x] `npm run test`通过

##### 详细描述 
在实际时，用到了brytunm 组件，在创建组件时会有 getElementById args为HTMlLElement 的情况，原生api会返回null，而由wujie 处理后并没有处理args为Object 的情况。
