### PR TITLE
fix: appendChildOrInsertBefore effect ignore css error

### DIFF
--- a/packages/wujie-core/src/effect.ts
+++ b/packages/wujie-core/src/effect.ts
@@ -205,16 +205,18 @@ function rewriteAppendOrInsertChild(opts: {
                   // 处理 ignore 样式
                   const rawAttrs = parseTagAttributes(element.outerHTML);
                   if (ignore && src) {
-                    const stylesheetElement = iframeDocument.createElement("link");
-                    const attrs = {
-                      ...rawAttrs,
-                      type: "text/css",
-                      rel: "stylesheet",
-                      href: src,
-                    };
-                    setAttrsToElement(stylesheetElement, attrs);
-                    rawDOMAppendOrInsertBefore.call(this, stylesheetElement, refChild);
-                    manualInvokeElementEvent(element, "load");
+                    // const stylesheetElement = iframeDocument.createElement("link");
+                    // const attrs = {
+                    //   ...rawAttrs,
+                    //   type: "text/css",
+                    //   rel: "stylesheet",
+                    //   href: src,
+                    // };
+                    // setAttrsToElement(stylesheetElement, attrs);
+                    // rawDOMAppendOrInsertBefore.call(this, stylesheetElement, refChild);
+                    // manualInvokeElementEvent(element, "load");
+                    // 忽略的元素应该直接把对应元素插入，而不是用新的 link 标签进行替代插入，保证 element 的上下文正常
+                    rawDOMAppendOrInsertBefore.call(this, element, refChild);
                   } else {
                     // 记录js插入样式，子应用重新激活时恢复
                     const stylesheetElement = iframeDocument.createElement("style");


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范

##### 详细描述

- 修复 effect.ts 中 appendChildOrInsertBefore 方法插入 ignore 元素时，应该插入目标元素而不是新建 link 元素做替换，从而保证目标元素的上下文

