### PR TITLE
Feat/unmount hook support promise

### DIFF
--- a/docs/guide/information.md
+++ b/docs/guide/information.md
@@ -48,7 +48,7 @@ interface Window {
   // 子应用mount函数
   __WUJIE_MOUNT: () => void;
   // 子应用unmount函数
-  __WUJIE_UNMOUNT: () => void;
+  __WUJIE_UNMOUNT: () => void | Promise<void>;
 }
 ```
 

--- a/docs/guide/start.md
+++ b/docs/guide/start.md
@@ -122,7 +122,7 @@ declare global {
     // 子应用mount函数
     __WUJIE_MOUNT: () => void;
     // 子应用unmount函数
-    __WUJIE_UNMOUNT: () => void;
+    __WUJIE_UNMOUNT: () => void | Promise<void>;
     // 子应用无界实例
     __WUJIE: { mount: () => void };
   }
@@ -189,7 +189,7 @@ declare global {
     // 子应用mount函数
     __WUJIE_MOUNT: () => void;
     // 子应用unmount函数
-    __WUJIE_UNMOUNT: () => void;
+    __WUJIE_UNMOUNT: () => void | Promise<void>;
   }
 }
 

--- a/docs/guide/variable.md
+++ b/docs/guide/variable.md
@@ -20,7 +20,7 @@ declare global {
     // 子应用mount函数
     __WUJIE_MOUNT: () => void;
     // 子应用unmount函数
-    __WUJIE_UNMOUNT: () => void;
+    __WUJIE_UNMOUNT: () => void | Promise<void>;
     // 注入对象
     $wujie: {
       bus: EventBus;

--- a/examples/angular12/src/main.ts
+++ b/examples/angular12/src/main.ts
@@ -13,7 +13,7 @@ declare global {
     // 子应用mount函数
     __WUJIE_MOUNT: () => void;
     // 子应用unmount函数
-    __WUJIE_UNMOUNT: () => void;
+    __WUJIE_UNMOUNT: () => void | Promise<void>;
   }
 }
 

--- a/examples/vite/src/main.ts
+++ b/examples/vite/src/main.ts
@@ -31,7 +31,7 @@ declare global {
     // 子应用mount函数
     __WUJIE_MOUNT: () => void;
     // 子应用unmount函数
-    __WUJIE_UNMOUNT: () => void;
+    __WUJIE_UNMOUNT: () => void | Promise<void>;
     // 子应用无界实例
     __WUJIE: { mount: () => void };
   }

--- a/packages/wujie-core/src/iframe.ts
+++ b/packages/wujie-core/src/iframe.ts
@@ -64,7 +64,7 @@ declare global {
     // 子应用mount函数
     __WUJIE_MOUNT: () => void;
     // 子应用unmount函数
-    __WUJIE_UNMOUNT: () => void;
+    __WUJIE_UNMOUNT: () => void | Promise<void>;
     // document type
     Document: typeof Document;
     // img type

--- a/packages/wujie-core/src/sandbox.ts
+++ b/packages/wujie-core/src/sandbox.ts
@@ -356,7 +356,7 @@ export default class Wujie {
   }
 
   /** 保活模式和使用proxyLocation.href跳转链接都不应该销毁shadow */
-  public unmount(): void {
+  public async unmount(): Promise<void> {
     this.activeFlag = false;
     // 清理子应用过期的同步参数
     clearInactiveAppUrl();
@@ -366,7 +366,7 @@ export default class Wujie {
     if (!this.mountFlag) return;
     if (isFunction(this.iframe.contentWindow.__WUJIE_UNMOUNT) && !this.alive && !this.hrefFlag) {
       this.lifecycles?.beforeUnmount?.(this.iframe.contentWindow);
-      this.iframe.contentWindow.__WUJIE_UNMOUNT();
+      await this.iframe.contentWindow.__WUJIE_UNMOUNT();
       this.lifecycles?.afterUnmount?.(this.iframe.contentWindow);
       this.mountFlag = false;
       this.bus.$clear();


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [x] 文档更改
- [x] 测试用例添加
- [x] `npm run test`通过

##### 详细描述

- 提供子应用完全控制 __WUJIE_UNMOUNT 的执行时机的能力，以便子应用可以在wujie真正卸载元素前，异步去做一些卸载后的清理等工作；
  - 再具体一些的某个场景事例,考虑如下 Vue 代码
 ```js 
// 某个子应用的代码
window.__WUJIE_UNMOUNT = () => {
    vueAppInstance.unmount();
};

// 子应用的某个组件的代码
onBeforeUnmount(() => {
      // 由于 vue 的执行机制，整个回调函数，会在下一个【微任务】中执行，而此时wujie 已经把清空了元素，document 变成了 null；会导致报错
      console.log( document.onselectstart ) ;
 });

---
当 wujie 子应用切换是，相关代码执行顺序如下:
① vueAppInstance.unmount回调执行，vue整个组件执行卸载，同时把组件的onBeforeUnmount回调放入微任务队列中  --> ② wujie同步地执行清除操作 --> ③ 执行 微任务中的 onBeforeUnmount 回调

修改后: 
② 的执行时机，可以由子应用 自行控制
```
