### PR TITLE
fix: 修复页面刷新子路由参数丢失的问题

### DIFF
--- a/packages/wujie-core/src/utils.ts
+++ b/packages/wujie-core/src/utils.ts
@@ -146,8 +146,13 @@ export function getAnchorElementQueryMap(anchorElement: HTMLAnchorElement): { [k
   const queryList = anchorElement.search.replace("?", "").split("&");
   const queryMap = {};
   queryList.forEach((query) => {
-    const [key, value] = query.split("=");
-    if (key && value) queryMap[key] = value;
+    const index = query.indexOf("=");
+    // 等于0的时候,key没有值,后面的逻辑也不会走
+    if (index > 0) {
+      const key = query.substring(0, index);
+      const value = query.substring(index + 1);
+      if (key && value) queryMap[key] = value;
+    }
   });
   return queryMap;
 }


### PR DESCRIPTION
当开启路由同步的时候，子页面有带参数，刷新浏览器子应用获取不到参数

<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [ ] 文档更改
- [ ] 测试用例添加
- [x] `npm run test`通过

##### 详细描述

- 问题描述
开启路由同步之后，子应用携带query参数跳转到自己的路由时，页面刷新，子应用无法获取到正常的参数。
是因为一顿给子应用iframe赋值之后,某些参数莫名的被解码了，导致 按照等于号分割的时候，忽略了后面的参数，如下图：

![image](https://github.com/Tencent/wujie/assets/8656782/9034f0e1-45b3-42f3-a128-600bc563e70c)

- 关联issue #295 
