### PR TITLE
fix: wujie-react watch props change, restart app

### DIFF
--- a/packages/wujie-react/index.js
+++ b/packages/wujie-react/index.js
@@ -34,6 +34,12 @@ export default class WujieReact extends React.PureComponent {
     this.startApp();
   }
 
+  componentDidUpdate(prevProps) {
+    if (this.props.name !== prevProps.name || this.props.url !== prevProps.url) {
+      this.startApp();
+    }
+  }
+
   render() {
     const { width, height } = this.props;
     const { myRef: ref } = this.state;


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [ ] 文档更改 (无需修改）
- [ ] 测试用例添加 (无需修改）
- [x] `npm run test`通过

##### 详细描述

- 特性： 修复wujie-react更新属性 url 子应用不刷新的问题。
- 关联issue： https://github.com/Tencent/wujie/issues/688
