### PR TITLE
fix(proxy): protect the program when getElementById throws an exception error

### DIFF
--- a/packages/wujie-core/src/constant.ts
+++ b/packages/wujie-core/src/constant.ts
@@ -43,3 +43,5 @@ export const WUJIE_TIPS_CSS_ERROR_REQUESTED = "样式请求出现错误";
 export const WUJIE_TIPS_HTML_ERROR_REQUESTED = "html请求出现错误";
 export const WUJIE_TIPS_REPEAT_RENDER = "无界组件短时间重复渲染了两次，可能存在性能问题请检查代码";
 export const WUJIE_TIPS_NO_SCRIPT = "目标Script尚未准备好或已经被移除";
+export const WUJIE_TIPS_GET_ELEMENT_BY_ID =
+  "不支持document.getElementById()传入特殊字符，请参考document.querySelector文档";

--- a/packages/wujie-core/src/proxy.ts
+++ b/packages/wujie-core/src/proxy.ts
@@ -2,7 +2,7 @@ import { patchElementEffect, renderIframeReplaceApp } from "./iframe";
 import { renderElementToContainer } from "./shadow";
 import { pushUrlToWindow } from "./sync";
 import { documentProxyProperties, rawDocumentQuerySelector } from "./common";
-import { WUJIE_TIPS_RELOAD_DISABLED } from "./constant";
+import { WUJIE_TIPS_RELOAD_DISABLED, WUJIE_TIPS_GET_ELEMENT_BY_ID } from "./constant";
 import {
   getTargetValue,
   anchorElementGenerator,
@@ -155,6 +155,7 @@ export function proxyGenerator(
                   )
                 );
               } catch (error) {
+                warn(WUJIE_TIPS_GET_ELEMENT_BY_ID);
                 return null;
               }
             },

--- a/packages/wujie-core/src/proxy.ts
+++ b/packages/wujie-core/src/proxy.ts
@@ -146,13 +146,17 @@ export function proxyGenerator(
               if (ctx !== iframe.contentDocument) {
                 return ctx[propKey]?.apply(ctx, args);
               }
-              return (
-                target.call(shadowRoot, `[id="${args[0]}"]`) ||
-                iframe.contentWindow.__WUJIE_RAW_DOCUMENT_QUERY_SELECTOR__.call(
-                  iframe.contentWindow.document,
-                  `#${args[0]}`
-                )
-              );
+              try {
+                return (
+                  target.call(shadowRoot, `[id="${args[0]}"]`) ||
+                  iframe.contentWindow.__WUJIE_RAW_DOCUMENT_QUERY_SELECTOR__.call(
+                    iframe.contentWindow.document,
+                    `#${args[0]}`
+                  )
+                );
+              } catch (error) {
+                return null;
+              }
             },
           });
         }


### PR DESCRIPTION


<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [x] `npm run test`通过

##### 详细描述

与[#547](https://github.com/Tencent/wujie/pull/547)想法一致，在子应用中`document.getElementById`会被代理成`querySelector`，而`querySelector`并不支持特殊字符的传递，比如当使用`document.getElementById('aa/1')`，会报错
![image](https://github.com/Tencent/wujie/assets/13422021/94221390-238f-46e3-b42b-246bc303ca05)

正常情况下`document.getElementById` 应该支持特殊字符，并且找不到的时候返回`null`，并不期望会报错；因此需要对`document.getElementById`代理做兼容异常处理