### PR TITLE
fix: 在afterUnmount的回调函数中，使用 destroyApp 方法时，bus 属性为null ，调用$clear()会报错

### DIFF
--- a/packages/wujie-core/src/sandbox.ts
+++ b/packages/wujie-core/src/sandbox.ts
@@ -369,7 +369,7 @@ export default class Wujie {
       this.iframe.contentWindow.__WUJIE_UNMOUNT();
       this.lifecycles?.afterUnmount?.(this.iframe.contentWindow);
       this.mountFlag = false;
-      this.bus.$clear();
+      this.bus?.$clear();
       if (!this.degrade) {
         clearChild(this.shadowRoot);
         // head body需要复用，每次都要清空事件


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [ ] `npm run test`通过

##### 详细描述

在afterUnmount的回调函数中，使用 destroyApp 方法时，bus 属性为null ，调用$clear()会报错,我们的场景相对复杂一点，需要考虑保活和不保活两种场景，不保活时需要销毁原来的应用，否则无法再次打开，所以这里需要加一个判断进行兼容

- 特性
- 关联issue
