### PR TITLE
fix: 修复降级模式会丢失事件监听器

### DIFF
--- a/packages/wujie-core/src/iframe.ts
+++ b/packages/wujie-core/src/iframe.ts
@@ -284,7 +284,7 @@ function recordEventListeners(iframeWindow: Window) {
     // 添加事件缓存
     const elementListenerList = sandbox.elementEventCacheMap.get(this);
     if (elementListenerList) {
-      if (!elementListenerList.find((listener) => listener.handler === handler)) {
+      if (!elementListenerList.find((listener) => listener.type === type && listener.handler === handler))  {
         elementListenerList.push({ type, handler, options });
       }
     } else sandbox.elementEventCacheMap.set(this, [{ type, handler, options }]);
@@ -299,7 +299,7 @@ function recordEventListeners(iframeWindow: Window) {
     // 清除缓存
     const elementListenerList = sandbox.elementEventCacheMap.get(this);
     if (elementListenerList) {
-      const index = elementListenerList?.findIndex((ele) => ele.handler === handler);
+      const index = elementListenerList?.findIndex((ele) => ele.type === type && ele.handler === handler);
       elementListenerList.splice(index, 1);
     }
     if (!elementListenerList?.length) {


### PR DESCRIPTION
某些页面使用降级模式，发现一些事件监听器丢失。
经排查，此处：
recordEventListeners：
if (!elementListenerList.find((listener) => listener.handler === handler)) {

这个判断只判断handler一样就是认为是相同事件监听器，不进行缓存，根据addEventListener的参数，type、handler、options、useCapture、wantsuntrusted五元组共同组成不同事件监听器，因此type不同、handler相同也应该缓存下来。

改为：
if (!elementListenerList.find((listener) => listener.type === type && listener.handler === handler))

应该能兼容99%的情况。

- [x] 提交符合commit规范

##### 详细描述


fixes #757 
