### PR TITLE
fix: 修复子应用无法使用 WebComponent 组件库，提示 adoptedstylesheets 问题

### DIFF
--- a/packages/wujie-core/src/common.ts
+++ b/packages/wujie-core/src/common.ts
@@ -190,6 +190,7 @@ export const windowRegWhiteList = [
   /resizeObserver$|mutationObserver$|intersectionObserver$/i,
   /height$|width$|left$/i,
   /^screen/i,
+  /CSSStyleSheet$/i,
   /X$|Y$/,
 ];
 


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [ ] 文档更改
- [ ] 测试用例添加
- [ ] `npm run test`通过

##### 详细描述

- 问题描述：
   在子应用里面使用常规 webcompents 组件如 [omi](https://github.com/Tencent/omi)、[fast](https://github.com/microsoft/fast)、[ionic-framework](https://github.com/ionic-team/ionic-framework) 等的时候，会出现组件无法加载的情况，提示如下报错：

<img width="579" alt="截屏2023-12-24 17 57 19" src="https://github.com/Tencent/wujie/assets/3851415/083b6ea1-5d24-4723-bda1-f5b837feaca5">


- 原因
  该问题是因为常规 webcompents 组件为了分离样式和代理，会通过 `new CSSStyleSheet()` 的方式将 css 样式添加到 adoptedStyleSheets  上，可以不使用组件库直接通过如下方法复现：
  在子应用里面添加如下代码
```javascript
const stylesheet = new CSSStyleSheet();
stylesheet.replaceSync('body { background: red !important; }')
document.adoptedStyleSheets = [...document.adoptedStyleSheets, stylesheet];
```

  正常使用 CSSStyleSheet 是没有问题的，但是该属性有个特性：
> Set sheet’s Constructor document to the associated Document for the current global object. [css-style-sheets](https://www.w3.org/TR/cssom-1/#css-style-sheets)

> The Window object has an associated Document, which is a Document object. It is set when the Window object is created, and only ever changed during navigation from the initial about:blank Document. [concept-document-window](https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window)

上面表示，每个 CSSStyleSheet 都会有一个 associated Document，而关联文档在 window 对象创建的时候就已经建立，子应用里面 `new CSSStyleSheet()`  的方式，采用的是子应用的 window.CSSStyleSheet, 关联文档是子应用的 document。

然而 wujie 采用 webcomponent + iframe 的沙箱模式，本身会通过 webcompent 的方式来挂载原本在 iframe 里面的 html 节点，这就会导致 iframe 里面创建的 CSSStyleSheet 关联文档从子应用的 document，变成主应用的 document，从而引发  Sharing constructed stylesheets in multiple documents is not allowed 问题

- 解决方法
  1. 对于老版本可以在生命周期 beforeLoad 里面修改 appWindow：`appWindow.CSSStyleSheet = appWindow.parent.CSSStyleSheet`
  2. CSSStyleSheet 关联文档的特性最好是将 iframeWindow.CSSStyleSheet 指向 iframeWindow.parent.CSSStyleSheet