### PR TITLE
fix: 修复多个子应用启动，拿到的全局对象缓存都是第一个子应用全局对象的bug

### DIFF
--- a/packages/wujie-core/src/proxy.ts
+++ b/packages/wujie-core/src/proxy.ts
@@ -71,7 +71,7 @@ export function proxyGenerator(
     },
 
     set: (target: Window, p: PropertyKey, value: any) => {
-      checkProxyFunction(value);
+      checkProxyFunction(target, value);
       target[p] = value;
       return true;
     },

--- a/packages/wujie-core/src/utils.ts
+++ b/packages/wujie-core/src/utils.ts
@@ -79,24 +79,36 @@ export function isConstructable(fn: () => any | FunctionConstructor) {
   return constructable;
 }
 
-const setFnCacheMap = new WeakMap<CallableFunction, CallableFunction>();
-export function checkProxyFunction(value: any) {
+// 修复多个子应用启动，拿到的全局对象都是第一个子应用全局对象的bug：https://github.com/Tencent/wujie/issues/770
+const setFnCacheMap = new WeakMap<
+  Window | Document | ShadowRoot | Location,
+  WeakMap<CallableFunction, CallableFunction>
+>();
+
+export function checkProxyFunction(target: Window | Document | ShadowRoot | Location, value: any) {
   if (isCallable(value) && !isBoundedFunction(value) && !isConstructable(value)) {
-    if (!setFnCacheMap.has(value)) {
-      setFnCacheMap.set(value, value);
+    if (!setFnCacheMap.has(target)) {
+      setFnCacheMap.set(target, new WeakMap());
+      setFnCacheMap.get(target).set(value, value);
+    } else if (!setFnCacheMap.get(target).has(value)) {
+      setFnCacheMap.get(target).set(value, value);
     }
   }
 }
 
 export function getTargetValue(target: any, p: any): any {
   const value = target[p];
-  if (setFnCacheMap.has(value)) {
-    return setFnCacheMap.get(value);
+  if (setFnCacheMap.has(target) && setFnCacheMap.get(target).has(value)) {
+    return setFnCacheMap.get(target).get(value);
   }
   if (isCallable(value) && !isBoundedFunction(value) && !isConstructable(value)) {
     const boundValue = Function.prototype.bind.call(value, target);
-    setFnCacheMap.set(value, boundValue);
-
+    if (setFnCacheMap.has(target)) {
+      setFnCacheMap.get(target).set(value, boundValue);
+    } else {
+      setFnCacheMap.set(target, new WeakMap());
+      setFnCacheMap.get(target).set(value, boundValue);
+    }
     for (const key in value) {
       boundValue[key] = value[key];
     }


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [ ] 文档更改
- [ ] 测试用例添加
- [ ] `npm run test`通过

##### 详细描述

- 特性

之前多个子应用共享缓存的全局对象，会导致多个子应用拿到的都是第一个子应用缓存的全局对象（Window、Location、ShadowRoot、Document）

现在修改成多个子应用缓存各自的全局对象

- 关联issue

[子应用使用CKEditor5富文本编辑器，改变url的query参数重新加载后光标异常 #768](https://github.com/Tencent/wujie/issues/768)

[页面中使用多个子应用时，子应用 getSelection() 指向错误 #770](https://github.com/Tencent/wujie/issues/770)