### PR TITLE
fix: 修复通过appendChild添加的外部脚本中使用document.body.removeChild移除脚本报错阻塞代码执行的问题

### DIFF
--- a/packages/wujie-core/src/iframe.ts
+++ b/packages/wujie-core/src/iframe.ts
@@ -7,6 +7,7 @@ import {
   isConstructable,
   anchorElementGenerator,
   isMatchSyncQueryById,
+  isFunction,
   warn,
   error,
   execHooks,
@@ -564,6 +565,7 @@ function patchNodeEffect(iframeWindow: Window): void {
   const rawGetRootNode = iframeWindow.Node.prototype.getRootNode;
   const rawAppendChild = iframeWindow.Node.prototype.appendChild;
   const rawInsertRule = iframeWindow.Node.prototype.insertBefore;
+  const rawRemoveChild = iframeWindow.Node.prototype.removeChild;
   iframeWindow.Node.prototype.getRootNode = function (options?: GetRootNodeOptions): Node {
     const rootNode = rawGetRootNode.call(this, options);
     if (rootNode === iframeWindow.__WUJIE.shadowRoot) return iframeWindow.document;
@@ -576,6 +578,21 @@ function patchNodeEffect(iframeWindow: Window): void {
   };
   iframeWindow.Node.prototype.insertBefore = function <T extends Node>(node: T, child: Node | null): T {
     const res = rawInsertRule.call(this, node, child);
+    patchElementEffect(node, iframeWindow);
+    return res;
+  };
+  iframeWindow.Node.prototype.removeChild = function <T extends Node>(node: T): T {
+    let res;
+    try {
+      res = rawRemoveChild.call(this, node);
+    } catch (e) {
+      console.warn(
+        `Failed to removeChild: ${node.nodeName.toLowerCase()} is not a child of ${this.nodeName.toLowerCase()}, try again with parentNode attribute. `
+      );
+      if (node.isConnected && isFunction(node.parentNode?.removeChild)) {
+        node.parentNode.removeChild(node);
+      }
+    }
     patchElementEffect(node, iframeWindow);
     return res;
   };


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [ ] 文档更改
- [ ] 测试用例添加
- [ ] `npm run test`通过

##### 详细描述

- 特性
一些第三方库内部会使用
```
const script = document.createElement("script");

script.onload = function () {
  document.body.removeChild(script);
};

document.body.appendChild(script)
```
这种形式关联自己的脚本资源，但由于wujie劫持了子应用的Node.prototype.appendChild并改变了脚本的实际执行环境，所以在removeChild的时候会报错阻塞脚本执行。

所以添加了对子应用removeChild的劫持，在调用时判断目标Node是否还与Document连接，并尝试使用Node.parentNode.removeChild进行移除。
- 关联issue
https://github.com/Tencent/wujie/issues/524