### PR TITLE
fix: 修复wujie-react重复渲染时保活模式输出undefined

### DIFF
--- a/packages/wujie-react/index.js
+++ b/packages/wujie-react/index.js
@@ -28,15 +28,19 @@ export default class WujieReact extends React.PureComponent {
     } catch (error) {
       console.log(error);
     }
-  }
-  
-  componentDidMount () {
-    this.startApp();
+  };
+
+  execStartApp = () => {
+    this.startAppQueue = this.startAppQueue.then(this.startApp);
+  };
+
+  componentDidMount() {
+    this.execStartApp();
   }
 
   componentDidUpdate(prevProps) {
     if (this.props.name !== prevProps.name || this.props.url !== prevProps.url) {
-      this.startApp();
+      this.execStartApp();
     }
   }
 
@@ -48,27 +52,27 @@ export default class WujieReact extends React.PureComponent {
 }
 
 const propTypes = {
-    height: PropTypes.string,
-    width: PropTypes.string,
-    name: PropTypes.string,
-    loading: PropTypes.element,
-    url: PropTypes.string,
-    alive: PropTypes.bool,
-    fetch: PropTypes.func,
-    props: PropTypes.object,
-    attrs: PropTypes.object,
-    replace: PropTypes.func,
-    sync: PropTypes.bool,
-    prefix: PropTypes.object,
-    fiber: PropTypes.bool,
-    degrade: PropTypes.bool,
-    plugins: PropTypes.array,
-    beforeLoad: PropTypes.func,
-    beforeMount: PropTypes.func,
-    afterMount: PropTypes.func,
-    beforeUnmount: PropTypes.func,
-    afterUnmount: PropTypes.func,
-    activated: PropTypes.func,
-    deactivated: PropTypes.func,
-    loadError: PropTypes.func,
-  }
+  height: PropTypes.string,
+  width: PropTypes.string,
+  name: PropTypes.string,
+  loading: PropTypes.element,
+  url: PropTypes.string,
+  alive: PropTypes.bool,
+  fetch: PropTypes.func,
+  props: PropTypes.object,
+  attrs: PropTypes.object,
+  replace: PropTypes.func,
+  sync: PropTypes.bool,
+  prefix: PropTypes.object,
+  fiber: PropTypes.bool,
+  degrade: PropTypes.bool,
+  plugins: PropTypes.array,
+  beforeLoad: PropTypes.func,
+  beforeMount: PropTypes.func,
+  afterMount: PropTypes.func,
+  beforeUnmount: PropTypes.func,
+  afterUnmount: PropTypes.func,
+  activated: PropTypes.func,
+  deactivated: PropTypes.func,
+  loadError: PropTypes.func,
+};


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [x] `npm run test`通过

##### 详细描述

- 特性

处理 React 组件重复渲染时 wujie.startApp() 的异步竞争导致的问题

- 关联issue

见 https://github.com/Tencent/wujie/pull/599
