### PR TITLE
fix: 修复子应用document.querySelectorAll('script')获取长度为0 (#822)

### DIFF
--- a/packages/wujie-core/src/proxy.ts
+++ b/packages/wujie-core/src/proxy.ts
@@ -172,12 +172,13 @@ export function proxyGenerator(
                 return ctx[propKey]?.apply(ctx, args);
               }
               // 二选一，优先shadowDom，除非采用array合并，排除base，防止对router造成影响
-              return (
-                target.apply(shadowRoot, args) ||
-                (args[0] === "base"
-                  ? null
-                  : iframe.contentWindow[rawPropMap[propKey]].call(iframe.contentWindow.document, args[0]))
-              );
+              const res = target.apply(shadowRoot, args);
+              if (res && (propKey === "querySelector" || res.length > 0)) {
+                return res;
+              }
+              return args[0] === "base"
+                ? null
+                : iframe.contentWindow[rawPropMap[propKey]].call(iframe.contentWindow.document, args[0]);
             },
           });
         }


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [x] `npm run test`通过

##### 详细描述

- 关联issue:https://github.com/Tencent/wujie/issues/822
