### PR TITLE
fix: 修复子应用无法使用 WebComponent 组件库，提示 adoptedstylesheets 问题 (#771)

### DIFF
--- a/packages/wujie-core/src/common.ts
+++ b/packages/wujie-core/src/common.ts
@@ -190,6 +190,7 @@ export const windowRegWhiteList = [
   /resizeObserver$|mutationObserver$|intersectionObserver$/i,
   /height$|width$|left$/i,
   /^screen/i,
+  /CSSStyleSheet$/i,
   /X$|Y$/,
 ];
 


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [ ] 文档更改
- [ ] 测试用例添加
- [ ] `npm run test`通过

##### 详细描述
更新提交信息