### PR TITLE
fix: 修复在降级情况下无法加载vite使用vite-legacy-plugin打包出的js文件

### DIFF
--- a/packages/wujie-core/src/common.ts
+++ b/packages/wujie-core/src/common.ts
@@ -41,7 +41,14 @@ export function addSandboxCacheWithOptions(id: string, options: cacheOptions): v
 // 分类document上需要处理的属性，不同类型会进入不同的处理逻辑
 export const documentProxyProperties = {
   // 降级场景下需要本地特殊处理的属性
-  modifyLocalProperties: ["createElement", "createTextNode", "documentURI", "URL", "getElementsByTagName"],
+  modifyLocalProperties: [
+    "createElement",
+    "createTextNode",
+    "documentURI",
+    "URL",
+    "getElementsByTagName",
+    "getElementById",
+  ],
 
   // 子应用需要手动修正的属性方法
   modifyProperties: [

--- a/packages/wujie-core/src/proxy.ts
+++ b/packages/wujie-core/src/proxy.ts
@@ -313,6 +313,14 @@ export function localGenerator(
         };
       },
     },
+    getElementById: {
+      get() {
+        return function (...args) {
+          const id = args[0];
+          return (sandbox.document.getElementById(id) as any) || iframe.contentDocument.getElementById(id);
+        };
+      },
+    },
   });
   // 普通处理
   const {


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [ ] 文档更改
- [ ] 测试用例添加
- [ ] `npm run test`通过

##### 详细描述

- 特性
使用vite-legacy-plugin插件打包后的兼容文件，会存在如下script代码：

```
    <script
      crossorigin
      id="vite-legacy-entry"
      data-src="https://tracker-online.oss-cn-beijing.aliyuncs.com/scripts/index-legacy.7f2776b7.js"
    >
      System.import(document.getElementById('vite-legacy-entry').getAttribute('data-src'));
    </script>
```

在wujie非降级模式下，对`getElementById`这个api做了script获取的兼容；而在降级模式下，并没有做兼容，导致`getElementById`的查找范围只有iframe sandbox 之中，而其上代码需要获取放在iframe contentDocument中的script标签，因为作用域不同，导致无法获取到。

我的修改是优先在 iframe sandbox 中查找元素，如果没有查找到则去iframe contentDocument查找，从而保证了可以找到script标签

- 关联issue
