### PR TITLE
fix: appWindowOnEvent 增加 onerror and onunhandledrejection 事件

### DIFF
--- a/packages/wujie-core/src/common.ts
+++ b/packages/wujie-core/src/common.ts
@@ -179,7 +179,7 @@ export const appWindowAddEventListenerEvents = [
 ];
 
 // 子应用window.onXXX需要挂载到iframe沙箱上的事件
-export const appWindowOnEvent = ["onload", "onbeforeunload", "onunload"];
+export const appWindowOnEvent = ["onload", "onbeforeunload", "onunload", "onerror", "onunhandledrejection"];
 
 // 相对路径问题元素的tag和attr的map
 export const relativeElementTagAttrMap = {


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [ ] 文档更改
- [ ] 测试用例添加
- [ ] `npm run test`通过

##### 详细描述
wujie在给子应用的window事件做监听代理时，少配置了onerror 和 onunhandledrejection，导致子应用无法正常监听这2个事件
