### PR TITLE
fix(shadow): 修复DOMParser渲染html元素丢失沙箱上下文的问题 #921

### DIFF
--- a/packages/wujie-core/src/shadow.ts
+++ b/packages/wujie-core/src/shadow.ts
@@ -181,7 +181,13 @@ function renderTemplateToHtml(iframeWindow: Window, template: string): HTMLHtmlE
   const parsedDocument = parser.parseFromString(template, "text/html");
 
   // 无论 template 是否包含html，documentElement 必然是 HTMLHtmlElement
-  let html = parsedDocument.documentElement as HTMLHtmlElement;
+  const parsedHtml = parsedDocument.documentElement as HTMLHtmlElement;
+  const sourceAttributes = parsedHtml.attributes;
+  let html = document.createElement("html");
+  html.innerHTML = template;
+  for (let i = 0; i < sourceAttributes.length; i++) {
+    html.setAttribute(sourceAttributes[i].name, sourceAttributes[i].value);
+  }
   // 组件多次渲染，head和body必须一直使用同一个来应对被缓存的场景
   if (!alive && execFlag) {
     html = replaceHeadAndBody(html, head, body);


### PR DESCRIPTION
##### Checklist

- [x] 提交符合commit规范

##### 详细描述

- 使用 DOMParser渲染的HTML DOM使其丢失了沙箱上下文，导致 #921 。
- 修复后，使用 1.0.22 以前的方法 `document.createElement("html")` 渲染出 HTML 元素，而 `DOMParser` 只作为 template 的解析器，将解析出的 html 标签属性赋值到有沙箱上下文的 HTML 元素。
