### PR TITLE
fix: 将 preOpstions 类型提示中 url 变为可选项

### DIFF
--- a/packages/wujie-core/src/index.ts
+++ b/packages/wujie-core/src/index.ts
@@ -125,9 +125,10 @@ type baseOptions = {
   loadError?: loadErrorHandler;
 };
 
-export type preOptions = baseOptions & {
+export type preOptions = Omit<baseOptions, 'url'> & {
   /** 预执行 */
   exec?: boolean;
+  url?: string;
 };
 
 export type startOptions = baseOptions & {


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [ ] 文档更改
- [ ] 测试用例添加
- [x] `npm run test`通过

##### 详细描述

- 特性
- 关联issue
