### PR TITLE
fix: 修复在 sandbox.document.getElementById 无法查询到时, 使用 iframe 调用回到 proxy 导致死循环

### DIFF
--- a/packages/wujie-core/src/proxy.ts
+++ b/packages/wujie-core/src/proxy.ts
@@ -317,7 +317,7 @@ export function localGenerator(
       get() {
         return function (...args) {
           const id = args[0];
-          return (sandbox.document.getElementById(id) as any) || iframe.contentDocument.getElementById(id);
+          return (sandbox.document.getElementById(id) as any);
         };
       },
     },


### PR DESCRIPTION
… 导致死循环

<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [ ] 文档更改
- [ ] 测试用例添加
- [ ] `npm run test`通过

##### 详细描述

- 特性
- 关联issue
