### PR TITLE
fix: 修复最顶层frame下存在不止一个wujie依赖包时的报错

### DIFF
--- a/packages/wujie-core/src/common.ts
+++ b/packages/wujie-core/src/common.ts
@@ -12,8 +12,7 @@ let getIdToSandboxCacheMap: () => Map<String, SandboxCache> = () => {
   let registeredWujie = window.customElements.get("wujie-app") as unknown as ReturnType<typeof createWujieApp>;
   if (registeredWujie) {
     return registeredWujie.idToSandboxCacheMap;
-  }
-  if (window.__POWERED_BY_WUJIE__) {
+  } else if (window.__POWERED_BY_WUJIE__) {
     return window.__WUJIE.inject.idToSandboxMap;
   } else {
     return new Map<String, SandboxCache>();

--- a/packages/wujie-core/src/common.ts
+++ b/packages/wujie-core/src/common.ts
@@ -1,5 +1,6 @@
 import Wujie from "./sandbox";
 import { cacheOptions } from "./index";
+import { createWujieApp } from "./shadow";
 export interface SandboxCache {
   wujie?: Wujie;
   options?: cacheOptions;
@@ -7,10 +8,20 @@ export interface SandboxCache {
 
 export type appAddEventListenerOptions = AddEventListenerOptions & { targetWindow?: Window };
 
+let getIdToSandboxCacheMap: () => Map<String, SandboxCache> = () => {
+  let registeredWujie = window.customElements.get("wujie-app") as unknown as ReturnType<typeof createWujieApp>;
+  if (registeredWujie) {
+    return registeredWujie.idToSandboxCacheMap;
+  }
+  if (window.__POWERED_BY_WUJIE__) {
+    return window.__WUJIE.inject.idToSandboxMap;
+  } else {
+    return new Map<String, SandboxCache>();
+  }
+};
+
 // 全部无界实例和配置存储map
-export const idToSandboxCacheMap = window.__POWERED_BY_WUJIE__
-  ? window.__WUJIE.inject.idToSandboxMap
-  : new Map<String, SandboxCache>();
+export const idToSandboxCacheMap = getIdToSandboxCacheMap();
 
 export function getWujieById(id: String): Wujie | null {
   return idToSandboxCacheMap.get(id)?.wujie || null;

--- a/packages/wujie-core/src/sandbox.ts
+++ b/packages/wujie-core/src/sandbox.ts
@@ -48,6 +48,7 @@ type lifecycles = {
  * 基于 Proxy和iframe 实现的沙箱
  */
 export default class Wujie {
+  static idToSandboxCacheMap = idToSandboxCacheMap;
   public id: string;
   /** 激活时路由地址 */
   public url: string;


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [ ] `npm run test`通过

##### 详细描述

以issue的复现案例项目为例，qiankun主应用下有两个子应用，这两个子应用都有使用wujie

打开app1后刷新再打开app2会报错，打开app2后刷新再打开app1会报错

这个pr修复了来自不同应用的wujie没有共享idToSandboxCacheMap的问题

- 特性
- 关联issue #955 
