### PR TITLE
fix: 类实例上的方法单独调用会将this指向更新为调用位置的this，导致startApp方法return出的destory方法的th…

### DIFF
--- a/packages/wujie-core/src/index.ts
+++ b/packages/wujie-core/src/index.ts
@@ -233,7 +233,7 @@ export async function startApp(startOptions: startOptions): Promise<Function | v
         await sandbox.start(getExternalScripts);
       }
       sandbox.lifecycles?.activated?.(sandbox.iframe.contentWindow);
-      return sandbox.destroy;
+      return () => sandbox.destroy();
     } else if (isFunction(iframeWindow.__WUJIE_MOUNT)) {
       /**
        * 子应用切换会触发webcomponent的disconnectedCallback调用sandbox.unmount进行实例销毁
@@ -248,7 +248,7 @@ export async function startApp(startOptions: startOptions): Promise<Function | v
       iframeWindow.__WUJIE_MOUNT();
       sandbox.lifecycles?.afterMount?.(sandbox.iframe.contentWindow);
       sandbox.mountFlag = true;
-      return sandbox.destroy;
+      return () => sandbox.destroy();
     } else {
       // 没有渲染函数
       sandbox.destroy();
@@ -273,7 +273,7 @@ export async function startApp(startOptions: startOptions): Promise<Function | v
   const processedHtml = await processCssLoader(newSandbox, template, getExternalStyleSheets);
   await newSandbox.active({ url, sync, prefix, template: processedHtml, el, props, alive, fetch, replace });
   await newSandbox.start(getExternalScripts);
-  return newSandbox.destroy;
+  return () => newSandbox.destroy();
 }
 
 /**


### PR DESCRIPTION
fix: 类实例上的方法单独调用会将this指向更新为调用位置的this，导致startApp方法return出的destory方法的this指向出现错误，这里改成箭头函数以规避问题
Fixes #954

<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范

##### 详细描述

- 特性
- 关联issue #954 
