### PR TITLE
feat: react，vue组件支持设置包围的div组件style

### DIFF
--- a/packages/wujie-react/index.js
+++ b/packages/wujie-react/index.js
@@ -45,9 +45,9 @@ export default class WujieReact extends React.PureComponent {
   }
 
   render() {
-    const { width, height } = this.props;
+    const { width, height, style } = this.props;
     const { myRef: ref } = this.state;
-    return <div style={{ width, height }} ref={ref} />;
+    return <div style={{ width, height, ...style }} ref={ref} />;
   }
 }
 
@@ -75,4 +75,5 @@ const propTypes = {
   activated: PropTypes.func,
   deactivated: PropTypes.func,
   loadError: PropTypes.func,
+  style: PropTypes.object,
 };

--- a/packages/wujie-vue2/index.js
+++ b/packages/wujie-vue2/index.js
@@ -27,6 +27,7 @@ const wujieVueOptions = {
     activated: { type: Function, default: null },
     deactivated: { type: Function, default: null },
     loadError: { type: Function, default: null },
+    style: { type: Object, default: undefined },
   },
   data() {
     return {
@@ -91,6 +92,7 @@ const wujieVueOptions = {
       style: {
         width: this.width,
         height: this.height,
+        ...this.style,
       },
       ref: "wujie",
     });

--- a/packages/wujie-vue3/index.js
+++ b/packages/wujie-vue3/index.js
@@ -27,6 +27,7 @@ const wujieVueOptions = {
     activated: { type: Function, default: null },
     deactivated: { type: Function, default: null },
     loadError: { type: Function, default: null },
+    style: { type: Object, default: undefined },
   },
   data() {
     return {
@@ -90,6 +91,7 @@ const wujieVueOptions = {
       style: {
         width: this.width,
         height: this.height,
+        ...this.style,
       },
       ref: "wujie",
     });


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范

##### 详细描述

- 特性 

支持设置包围的div元素的样式

`
<WujieReact
     style={{
        overflow: "auto",
      }}></WujieReact>
`

