### PR TITLE
fix: '处理modulepreload类型的link标签'

### DIFF
--- a/packages/wujie-core/src/effect.ts
+++ b/packages/wujie-core/src/effect.ts
@@ -195,8 +195,22 @@ function rewriteAppendOrInsertChild(opts: {
     if (element.tagName) {
       switch (element.tagName?.toUpperCase()) {
         case "LINK": {
-          const { href, rel, type } = element as HTMLLinkElement;
+          const { href, rel, type, as } = element as HTMLLinkElement;
           const styleFlag = rel === "stylesheet" || type === "text/css" || href.endsWith(".css");
+          // 处理modulepreload类型的link标签
+          if (rel === "modulepreload") {
+            // 对于JS类型的modulepreload，记录但不立即插入
+            if (as === "script" && href.endsWith(".js")) {
+              console.warn('as === "script"',as === "script");
+              // 执行插件钩子，但不插入DOM
+              execHooks(plugins, "appendOrInsertElementHook", element, iframe.contentWindow);
+              return null;
+            }
+            // 对于非JS类型的modulepreload（字体、图片等），正常插入DOM
+            const res = rawDOMAppendOrInsertBefore.call(this, element, refChild);
+            execHooks(plugins, "appendOrInsertElementHook", element, iframe.contentWindow);
+            return res;
+          }
           // 非 stylesheet 不做处理
           if (!styleFlag) {
             const res = rawDOMAppendOrInsertBefore.call(this, element, refChild);


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x ] 提交符合commit规范
##### 详细描述
fix(core): 防止modulepreload脚本重复加载

当使用vite打包的子应用时，带有as="script"的modulepreload链接标签会导致
同一个JS文件被加载两次，浪费网络资源并影响性能。

此更改添加了对modulepreload链接标签的特殊处理：
- 阻止as="script"的JS文件插入DOM
- 允许其他类型的modulepreload资源(字体、图片等)正常加载
- 执行插件钩子以保持现有功能

此修复专门针对重复加载问题，同时保留非脚本资源的预加载功能。
- 关联issue #1049
