### PR TITLE
fix(effect): add custom removeChild and contains methods

### DIFF
--- a/packages/wujie-core/src/effect.ts
+++ b/packages/wujie-core/src/effect.ts
@@ -47,6 +47,21 @@ function patchCustomEvent(
 }
 
 /**
+ * 为动态创建的元素设置模拟的 parentNode
+ * 用于兼容第三方库（如高德地图）在 onload 回调中调用 parentNode.removeChild 的情况
+ */
+function patchParentNode(element: HTMLElement): void {
+  if (element.parentNode === null) {
+    Object.defineProperty(element, "parentNode", {
+      configurable: true,
+      get: () => ({
+        removeChild: (child: Node) => child,
+      }),
+    });
+  }
+}
+
+/**
  * 手动触发事件回调
  */
 function manualInvokeElementEvent(element: HTMLLinkElement | HTMLScriptElement, event: string): void {
@@ -238,11 +253,15 @@ function rewriteAppendOrInsertChild(opts: {
                     rawDOMAppendOrInsertBefore.call(this, stylesheetElement, refChild);
                     // 处理样式补丁
                     handleStylesheetElementPatch(stylesheetElement, sandbox);
+                    // 兼容第三方库在 onload 中调用 parentNode.removeChild 的情况
+                    patchParentNode(element);
                     manualInvokeElementEvent(element, "load");
                   }
                   element = null;
                 },
                 () => {
+                  // 兼容第三方库在 onerror 中调用 parentNode.removeChild 的情况
+                  patchParentNode(element);
                   manualInvokeElementEvent(element, "error");
                   element = null;
                 }
@@ -275,6 +294,8 @@ function rewriteAppendOrInsertChild(opts: {
               // 假如子应用被连续渲染两次，两次渲染会导致处理流程的交叉污染
               if (sandbox.iframe === null) return warn(WUJIE_TIPS_REPEAT_RENDER);
               const onload = () => {
+                // 兼容第三方库在 onload 中调用 parentNode.removeChild 的情况
+                patchParentNode(element);
                 manualInvokeElementEvent(element, "load");
                 element = null;
               };
@@ -305,6 +326,8 @@ function rewriteAppendOrInsertChild(opts: {
                     if (!execQueueLength) sandbox.execQueue.shift()();
                   },
                   () => {
+                    // 兼容第三方库在 onerror 中调用 parentNode.removeChild 的情况
+                    patchParentNode(element);
                     manualInvokeElementEvent(element, "error");
                     element = null;
                   }

--- a/packages/wujie-core/src/effect.ts
+++ b/packages/wujie-core/src/effect.ts
@@ -470,4 +470,12 @@ export function patchRenderEffect(render: ShadowRoot | Document, id: string, deg
     rawDOMAppendOrInsertBefore: rawBodyInsertBefore as any,
     wujieId: id,
   }) as typeof rawBodyInsertBefore;
+  render.body.removeChild = rewriteRemoveChild({
+    rawElementRemoveChild: rawElementRemoveChild.bind(render.body),
+    wujieId: id,
+  }) as typeof rawElementRemoveChild;
+  render.body.contains = rewriteContains({
+    rawElementContains: rawElementContains.bind(render.body),
+    wujieId: id,
+  }) as typeof rawElementContains;
 }


### PR DESCRIPTION
<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [x] `npm run test`通过

##### 详细描述

Firefox中直接打开高德地图子应用会报错Node.removeChild,通过在render中重写removeChild修复了改问题

- 关联issue
[高德地图在子应用中轨迹回放时报removeChild异常](https://github.com/Tencent/wujie/issues/524)