### PR TITLE
fix: 子应用使用vite时，第二个css以后加载的font-face无效

### DIFF
--- a/packages/wujie-core/src/effect.ts
+++ b/packages/wujie-core/src/effect.ts
@@ -155,6 +155,8 @@ function patchStylesheetElement(
       value: function (this: HTMLStyleElement, position: InsertPosition, element: Element) {
         if (element.nodeName === "STYLE") {
           nextTick(() => handleStylesheetElementPatch(element as HTMLStyleElement, sandbox));
+          element.insertAdjacentElement = this.insertAdjacentElement;
+          element.textContent = cssLoader(element.textContent, "", curUrl);
           const res = rawInsertAdjacentElement.call(this, position, element);
           sandbox.styleSheetElements.push(element as HTMLStyleElement);
           return res;


### PR DESCRIPTION


<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范

##### 详细描述

- 特性
  当子应用使用vite时，第二个以后加载的font-face无效
  在insertAdjacentElement内，替换patch元素的原始insertAdjacentElement
  并且重新使用cssLoader重新修改文件内加载资源的路径

- 关联issue
  https://github.com/Tencent/wujie/issues/1059
