### PR TITLE
fix(wujie-core): proxy document.adoptedStyleSheets to shadowRoot

### DIFF
--- a/packages/wujie-core/__test__/integration/adoptedStyleSheets.test.ts
+++ b/packages/wujie-core/__test__/integration/adoptedStyleSheets.test.ts
@@ -1,0 +1,81 @@
+import { awaitConsoleLogMessage } from "./utils";
+import { reactMainAppInfoMap, vueMainAppInfoMap, vueMainAppNameList, reactMainAppNameList } from "./common";
+
+const generateTest = (
+  AppInfoMap: typeof reactMainAppInfoMap | typeof vueMainAppInfoMap,
+  AppNameList: typeof vueMainAppNameList | typeof reactMainAppNameList,
+) => {
+  AppNameList.slice(0, 1).forEach((appName) => {
+    it("adoptedStyleSheets proxy test", async () => {
+      const childApplicationMountedPromise = awaitConsoleLogMessage(page, AppInfoMap[appName].mountedMessage);
+      await page.click(AppInfoMap[appName].linkSelector);
+      await childApplicationMountedPromise;
+
+      const result = await page.evaluate((childName) => {
+        const childWindowCollection = [window[0], window[1], window[2], window[3], window[4], window[5]];
+        const childWindow: any = childWindowCollection.find((itemWindow) => itemWindow.name === childName);
+        const sandbox = childWindow.__WUJIE;
+
+        if (sandbox.degrade) {
+          return { skipped: true, reason: "degrade mode" };
+        }
+
+        const shadowRoot = sandbox.shadowRoot as ShadowRoot;
+        const iframeDocument = childWindow.document;
+
+        const sheet = new childWindow.CSSStyleSheet();
+        sheet.replaceSync("body { --test-var: 1; }");
+
+        iframeDocument.adoptedStyleSheets = [sheet];
+
+        const isSameReference = iframeDocument.adoptedStyleSheets === shadowRoot.adoptedStyleSheets;
+        const hasSheet = shadowRoot.adoptedStyleSheets.length === 1;
+
+        iframeDocument.adoptedStyleSheets = [];
+        const isCleared = shadowRoot.adoptedStyleSheets.length === 0;
+
+        return {
+          skipped: false,
+          isSameReference,
+          hasSheet,
+          isCleared,
+        };
+      }, appName);
+
+      if (result.skipped) {
+        console.log(`Skipped: ${result.reason}`);
+        return;
+      }
+
+      expect(result.isSameReference).toBe(true);
+      expect(result.hasSheet).toBe(true);
+      expect(result.isCleared).toBe(true);
+    });
+  });
+};
+
+describe("main react adoptedStyleSheets", () => {
+  beforeAll(async () => {
+    await page.evaluateOnNewDocument(() => {
+      localStorage.clear();
+      localStorage.setItem("preload", "false");
+      localStorage.setItem("degrade", "false");
+    });
+    await page.goto("http://localhost:7700/");
+  });
+
+  generateTest(reactMainAppInfoMap, reactMainAppNameList);
+});
+
+describe("main vue adoptedStyleSheets", () => {
+  beforeAll(async () => {
+    await page.evaluateOnNewDocument(() => {
+      localStorage.clear();
+      localStorage.setItem("preload", "false");
+      localStorage.setItem("degrade", "false");
+    });
+    await page.goto("http://localhost:8000/");
+  });
+
+  generateTest(vueMainAppInfoMap, vueMainAppNameList);
+});

--- a/packages/wujie-core/src/shadow.ts
+++ b/packages/wujie-core/src/shadow.ts
@@ -46,6 +46,28 @@ export function defineWujieWebComponent() {
         const sandbox = getWujieById(this.getAttribute(WUJIE_APP_ID));
         patchElementEffect(shadowRoot, sandbox.iframe.contentWindow);
         sandbox.shadowRoot = shadowRoot;
+        // 将 document.adoptedStyleSheets 代理到 shadowRoot.adoptedStyleSheets
+        if (!sandbox.degrade) {
+          const iframeWindow = sandbox.iframe.contentWindow;
+          const descriptor: PropertyDescriptor = {
+            configurable: true,
+            enumerable: true,
+            get: () => shadowRoot.adoptedStyleSheets,
+            set: (sheets: CSSStyleSheet[]) => {
+              shadowRoot.adoptedStyleSheets = sheets;
+            },
+          };
+          try {
+            Object.defineProperty(iframeWindow.Document.prototype, "adoptedStyleSheets", descriptor);
+          } catch (e) {
+            /* ignore */
+          }
+          try {
+            Object.defineProperty(iframeWindow.document, "adoptedStyleSheets", descriptor);
+          } catch (e) {
+            /* ignore */
+          }
+        }
       }
 
       disconnectedCallback(): void {


### PR DESCRIPTION
## Summary

在非降级模式下，将 `document.adoptedStyleSheets` 代理到 `shadowRoot.adoptedStyleSheets`。

fix #209

## Problem

当子应用使用基于 `adoptedStyleSheets` 的 WebComponent（如 IconPark）时，会报错：

```
Uncaught DOMException: Failed to set the 'adoptedStyleSheets' property on 'ShadowRoot': 
Sharing constructed stylesheets in multiple documents is not allowed
```

原因是 wujie 将子应用的 UI 渲染在 shadowRoot 中，但 `document.adoptedStyleSheets` 仍然指向 iframe 的 document，导致 constructed stylesheets 无法在不同 document 之间共享。

## Solution

在 `WujieApp.connectedCallback` 中（shadowRoot 创建之后），将 `document.adoptedStyleSheets` 的 getter/setter 代理到 `shadowRoot.adoptedStyleSheets`：

- 代理 `Document.prototype.adoptedStyleSheets`
- 代理 `document.adoptedStyleSheets` 实例属性

## Changes

- `packages/wujie-core/src/shadow.ts`: 在 `connectedCallback` 中添加 adoptedStyleSheets 代理逻辑
- `packages/wujie-core/__test__/integration/adoptedStyleSheets.test.ts`: 添加测试用例

## Testing

已在实际项目中验证：
1. 基于 `adoptedStyleSheets` 的样式控制器正常工作
2. 动态添加/移除样式表正确反映在 shadowRoot 中
3. 不影响降级模式（degrade mode）的行为