### PR TITLE
fix: add missing comma in :prefix prop object to fix syntax error

### DIFF
--- a/docs/guide/sync.md
+++ b/docs/guide/sync.md
@@ -1,4 +1,5 @@
 # 路由同步
+
 ## 路由同步
 
 路由同步会将子应用路径的`path+query+hash`通过`window.encodeURIComponent`编码后挂载在主应用`url`的查询参数上，其中`key`值为子应用的 [name](/api/startApp.html#name)。
@@ -28,11 +29,10 @@
   :sync="true"
   :prefix="{
     prod: '/example/prod',
-    test: '/example/test'
+    test: '/example/test',
     prodId: '/example/prod/debug?id=',
   }"
 ></WujieVue>
-
 ```
 
 此时子应用不同路径将转换如下：


### PR DESCRIPTION
##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [x] 文档更改
- [ ] 测试用例添加
- [ ] `npm run test`通过

##### 详细描述

A missing comma between properties in the :prefix object led to a syntax error.
This commit adds the missing comma after the 'test' property for correct parsing.
