### PR TITLE
fix(docs): 修复指南页 navbar 响应式问题

### DIFF
--- a/docs/.vitepress/theme/styles/DocSearch.css
+++ b/docs/.vitepress/theme/styles/DocSearch.css
@@ -68,3 +68,20 @@
     background-position: 0 0;
   }
 }
+
+@media (min-width: 768px) and (max-width: 1099px) {
+  .DocSearch-Button {
+    justify-content: center;
+    padding: 0;
+    width: 40px;
+  }
+
+  .DocSearch-Button-Container {
+    margin: 0;
+  }
+
+  .DocSearch-Button-Placeholder,
+  .DocSearch-Button-Keys {
+    display: none;
+  }
+}

--- a/docs/.vitepress/theme/styles/vars.css
+++ b/docs/.vitepress/theme/styles/vars.css
@@ -83,3 +83,21 @@
 .VPButton.medium {
   border-radius: 0px;
 }
+
+@media (min-width: 768px) and (max-width: 1099px) {
+  .VPNavBarMenuLink,
+  .VPNavBarMenuGroup .button,
+  .VPNavBarMenuGroup .text {
+    white-space: nowrap;
+  }
+
+  .VPNavBarMenuLink,
+  .VPNavBarMenuGroup .button {
+    padding: 0 6px;
+  }
+
+  .VPNavBarSearch {
+    flex-grow: 0;
+    padding-left: 16px;
+  }
+}


### PR DESCRIPTION
## Summary
- prevent top nav labels from wrapping in the medium-width docs layout
- collapse the custom DocSearch button to an icon between 768px and 1099px so the navbar keeps enough horizontal space
- keep the guide page navbar stable across the reported responsive range

## Verification
- pnpm --filter wujie-docs docs:build
- checked `/doc/wujie/` locally at 768px, 827px, 960px, 1100px and 1250px

Closes #1071