### PR TITLE
ci: 新增 PR 测试 workflow，自动跑全量单测与集成测试

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -83,12 +83,18 @@ jobs:
       - name: Install dependencies
         run: pnpm i --filter "wujie-project" --filter "./packages/**" --filter "./examples/**" --frozen-lockfile
 
+      # examples 通过 main/module 字段引用 wujie / wujie-react / wujie-vue2 / wujie-vue3
+      # 的 lib/esm 产物，这些目录由 prepack（build.sh）生成。CI 全新仓库没有产物，
+      # 直接启动 dev server 会让主应用拿到空模块 → 页面空白 → 后续 selector 全找不到
+      - name: Build framework packages
+        env:
+          NODE_OPTIONS: --openssl-legacy-provider
+        run: ./node_modules/.bin/lerna run prepack
+
       - name: Run integration tests
         working-directory: packages/wujie-core
         env:
-          # 兼容 webpack 4 + Node 17+ 的 OpenSSL provider 限制
           NODE_OPTIONS: --openssl-legacy-provider
-          # puppeteer 在 CI 容器里需要禁用 sandbox
           PUPPETEER_LAUNCH_ARGS: "--no-sandbox --disable-setuid-sandbox"
         run: pnpm run test:integration
 

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -1,0 +1,101 @@
+name: PR Tests
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "notes/**"
+
+# 同一 PR 连续推送时自动取消上一次未完成的运行，节省 runner 时间
+concurrency:
+  group: pr-tests-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  unit:
+    name: Unit tests (jsdom)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 7.9.5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18.x"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm i --filter "wujie-project" --filter "./packages/**" --frozen-lockfile
+
+      - name: Run unit tests
+        working-directory: packages/wujie-core
+        run: pnpm run test:unit
+
+      - name: Job summary
+        if: always()
+        run: |
+          echo "## Unit tests" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ job.status }}" = "success" ]; then
+            echo ":white_check_mark: All unit tests passed." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo ":x: Unit tests failed - see job logs above." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+  integration:
+    name: Integration tests (puppeteer)
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    needs: unit
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 7.9.5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18.x"
+          cache: "pnpm"
+
+      # 提高 inotify watcher 上限，避免 8 个 webpack/vue/vite dev server 并行启动
+      # 时触发 ENOSPC（GitHub runner 默认上限对多 dev-server 场景偏紧）
+      - name: Raise inotify limits
+        run: |
+          sudo sysctl -w fs.inotify.max_user_watches=524288
+          sudo sysctl -w fs.inotify.max_user_instances=512
+
+      - name: Install dependencies
+        run: pnpm i --filter "wujie-project" --filter "./packages/**" --frozen-lockfile
+
+      - name: Run integration tests
+        working-directory: packages/wujie-core
+        env:
+          # 兼容 webpack 4 + Node 17+ 的 OpenSSL provider 限制
+          NODE_OPTIONS: --openssl-legacy-provider
+          # puppeteer 在 CI 容器里需要禁用 sandbox
+          PUPPETEER_LAUNCH_ARGS: "--no-sandbox --disable-setuid-sandbox"
+        run: pnpm run test:integration
+
+      - name: Job summary
+        if: always()
+        run: |
+          echo "## Integration tests" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ job.status }}" = "success" ]; then
+            echo ":white_check_mark: All integration tests passed." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo ":x: Integration tests failed - see job logs above." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -77,8 +77,11 @@ jobs:
           sudo sysctl -w fs.inotify.max_user_watches=524288
           sudo sysctl -w fs.inotify.max_user_instances=512
 
+      # 集成测试需要在 8 个 examples/* 下启动各自的 dev server
+      # （react-dev-utils/@vue/cli-service/@angular/cli/vite 等依赖都在 example 里），
+      # 所以安装范围必须覆盖 examples/**，不能沿用 publish 流水线只装 packages/** 的做法
       - name: Install dependencies
-        run: pnpm i --filter "wujie-project" --filter "./packages/**" --frozen-lockfile
+        run: pnpm i --filter "wujie-project" --filter "./packages/**" --filter "./examples/**" --frozen-lockfile
 
       - name: Run integration tests
         working-directory: packages/wujie-core

--- a/packages/wujie-core/__test__/integration/font.test.ts
+++ b/packages/wujie-core/__test__/integration/font.test.ts
@@ -1,4 +1,4 @@
-import { awaitConsoleLogMessage, triggerClickByJsSelector, sleep } from "./utils";
+import { awaitConsoleLogMessage, triggerClickByJsSelector } from "./utils";
 import { reactMainAppInfoMap, vueMainAppInfoMap } from "./common";
 
 describe("main react startApp", () => {
@@ -22,9 +22,10 @@ describe("main react startApp", () => {
     await appInfoFontMountedPromise;
     // 等待字体加载
     await page.waitForResponse((response) => response.url().includes("https://tdesign.gtimg.com/icon/"));
-    // 等待字体装载
-    await sleep(1000);
-    // 检查字体是否生效
+    // 等待字体装载到 FontFaceSet（拿到 response 后浏览器还要 parse + register，
+    // 注册时机受主进程繁忙程度影响，CI 上常见 > 1s，因此用 waitForFunction
+    // 替代固定 sleep，避免 flaky）
+    await page.waitForFunction(() => document.fonts.check("12px t", "E07F"), { timeout: 5000 });
     expect(await page.evaluate(() => document.fonts.check("12px t", "E07F"))).toBe(true);
   });
 });
@@ -49,9 +50,10 @@ describe("main vue startApp", () => {
     await appInfoFontMountedPromise;
     // 等待字体加载
     await page.waitForResponse((response) => response.url().includes("https://tdesign.gtimg.com/icon/"));
-    // 等待字体装载
-    await sleep(1000);
-    // 检查字体是否生效
+    // 等待字体装载到 FontFaceSet（拿到 response 后浏览器还要 parse + register，
+    // 注册时机受主进程繁忙程度影响，CI 上常见 > 1s，因此用 waitForFunction
+    // 替代固定 sleep，避免 flaky）
+    await page.waitForFunction(() => document.fonts.check("12px t", "E07F"), { timeout: 5000 });
     expect(await page.evaluate(() => document.fonts.check("12px t", "E07F"))).toBe(true);
   });
 });

--- a/packages/wujie-core/jest-puppeteer.config.js
+++ b/packages/wujie-core/jest-puppeteer.config.js
@@ -1,11 +1,16 @@
 const { resolve } = require("path");
 const LERNA_EXEC = resolve(__dirname, "../../node_modules/.bin/lerna");
 
+// CI 环境（如 GitHub Actions）需要 --no-sandbox，由 PUPPETEER_LAUNCH_ARGS 注入；
+// 本地开发不设置该变量时保持默认行为
+const launchArgs = (process.env.PUPPETEER_LAUNCH_ARGS || "").split(/\s+/).filter(Boolean);
+
 module.exports = {
   launch: {
     headless: true,
     devtools: false,
     product: "chrome",
+    ...(launchArgs.length ? { args: launchArgs } : {}),
   },
   server: [
     {


### PR DESCRIPTION
- 新增 .github/workflows/pr-test.yml：在 PR 到 master 时按串行触发 unit（jsdom，13 套件 64 用例）与 integration（jest-puppeteer + 8 个 example dev server），结果通过 GitHub Checks 直接展示在 PR 上。
- jest-puppeteer.config.js 支持读取 PUPPETEER_LAUNCH_ARGS 环境变量， CI 容器中注入 --no-sandbox 启动参数；本地未设置该变量时维持默认行为。
- 启用 concurrency cancel-in-progress：同一 PR 后续推送自动取消上一次 未完成的运行，避免占用 runner。

<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [ ] 提交符合commit规范
- [ ] 文档更改
- [ ] 测试用例添加
- [ ] `npm run test`通过

##### 详细描述

- 特性
- 关联issue
