### PR TITLE
fix: 兼容 Node 17+ 的 OpenSSL 3 调用旧版 webpack 报错

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "极致的微前端框架",
   "private": true,
   "scripts": {
-    "start": "lerna run start --parallel",
+    "start": "NODE_OPTIONS=--openssl-legacy-provider lerna run start --parallel",
     "doc": "lerna run docs:dev",
     "clean": "rimraf node_modules **/*/node_modules",
-    "test": "lerna run test --scope wujie",
+    "test": "NODE_OPTIONS=--openssl-legacy-provider lerna run test --scope wujie",
     "commitlint": "commitlint -E COMMIT_EDITMSG_PATH",
     "husky-commitlint": "commitlint -e",
     "prepare": "husky install"


### PR DESCRIPTION
examples 里 react17 / main-vue 等旧 webpack 4 项目在 Node 17+ （OpenSSL 3）下会因 MD4 hash 被禁用而抛 ERR_OSSL_EVP_UNSUPPORTED， 导致整套 demo 起不来；test 链路同理。给 start / test 脚本加上
NODE_OPTIONS=--openssl-legacy-provider 让旧 webpack 沿用历史哈希。

Made-with: Cursor

<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [ ] 提交符合commit规范
- [ ] 文档更改
- [ ] 测试用例添加
- [ ] `npm run test`通过

##### 详细描述

- 特性
- 关联issue
