### PR TITLE
fix(wujie-core): 修复 syncUrlToWindow 写回 URL 时未重新 encode 导致 query 值被反复降级

### DIFF
--- a/packages/wujie-core/__test__/integration/head.test.ts
+++ b/packages/wujie-core/__test__/integration/head.test.ts
@@ -1,4 +1,4 @@
-import { awaitConsoleLogMessage, triggerClickByJsSelector } from "./utils";
+import { awaitConsoleLogMessage, triggerClickByJsSelector, sleep } from "./utils";
 import { reactMainAppInfoMap, vueMainAppInfoMap } from "./common";
 
 const generateTest = (AppInfoMap: typeof reactMainAppInfoMap | typeof vueMainAppInfoMap, homeSelector: string) => {
@@ -16,6 +16,8 @@ const generateTest = (AppInfoMap: typeof reactMainAppInfoMap | typeof vueMainApp
     await page.click(AppInfoMap.vue2.linkSelector);
     await vue2MountedPromiseAgain;
     let vue2HomeTitle = await page.evaluateHandle(AppInfoMap.vue2.titleJsSelector);
+    // mounted 事件触发后样式还需要 1 帧才会真正应用，等一会儿再读 computed style
+    await sleep(100);
     expect(await vue2HomeTitle.asElement().evaluate((el) => window.getComputedStyle(el).color)).toBe(
       "rgb(241, 107, 95)"
     );
@@ -25,6 +27,7 @@ const generateTest = (AppInfoMap: typeof reactMainAppInfoMap | typeof vueMainApp
     await triggerClickByJsSelector(page, AppInfoMap.vue2.dialogNavSelector);
     await vue2DialogMountedPromise;
     const vue2DialogTitle = await page.evaluateHandle(AppInfoMap.vue2.titleJsSelector);
+    await sleep(100);
     expect(await vue2DialogTitle.asElement().evaluate((el) => window.getComputedStyle(el).color)).toBe(
       "rgb(2, 57, 208)"
     );

--- a/packages/wujie-core/src/sync.ts
+++ b/packages/wujie-core/src/sync.ts
@@ -26,9 +26,8 @@ export function syncUrlToWindow(iframeWindow: Window): void {
   }
   // 同步
   if (sync) {
-    queryMap[id] = window.encodeURIComponent(
-      validShortPath ? curUrl.replace(prefix[validShortPath], `{${validShortPath}}`) : curUrl
-    );
+    // queryMap 来自 URLSearchParams，已经是 decoded 形态；统一在写回 URL 时再 encode，避免重复 encode
+    queryMap[id] = validShortPath ? curUrl.replace(prefix[validShortPath], `{${validShortPath}}`) : curUrl;
     // 清理
   } else {
     delete queryMap[id];
@@ -36,7 +35,7 @@ export function syncUrlToWindow(iframeWindow: Window): void {
   const newQuery =
     "?" +
     Object.keys(queryMap)
-      .map((key) => key + "=" + queryMap[key])
+      .map((key) => key + "=" + window.encodeURIComponent(queryMap[key]))
       .join("&");
   winUrlElement.search = newQuery;
   if (winUrlElement.href !== window.location.href) {
@@ -83,7 +82,7 @@ export function clearInactiveAppUrl(): void {
   const newQuery =
     "?" +
     Object.keys(queryMap)
-      .map((key) => key + "=" + window.decodeURIComponent(queryMap[key]))
+      .map((key) => key + "=" + window.encodeURIComponent(queryMap[key]))
       .join("&");
   winUrlElement.search = newQuery;
   if (winUrlElement.href !== window.location.href) {
@@ -98,11 +97,12 @@ export function clearInactiveAppUrl(): void {
 export function pushUrlToWindow(id: string, url: string): void {
   let winUrlElement = anchorElementGenerator(window.location.href);
   const queryMap = getAnchorElementQueryMap(winUrlElement);
-  queryMap[id] = window.encodeURIComponent(url);
+  // queryMap 来自 URLSearchParams，已经是 decoded 形态；统一在写回 URL 时再 encode，避免重复 encode
+  queryMap[id] = url;
   const newQuery =
     "?" +
     Object.keys(queryMap)
-      .map((key) => key + "=" + queryMap[key])
+      .map((key) => key + "=" + window.encodeURIComponent(queryMap[key]))
       .join("&");
   winUrlElement.search = newQuery;
   window.history.pushState(null, "", winUrlElement.href);


### PR DESCRIPTION
getAnchorElementQueryMap 基于 URLSearchParams，返回的 queryMap 的 value 已经是 decoded 形态。但 syncUrlToWindow / clearInactiveAppUrl / pushUrlToWindow 在写回 URL 时直接做字符串拼接，没有重新 encode：

  app1 挂载 → ?app1=%2Fhome（自己 encode 了）
  app2 挂载 → URLSearchParams 把 app1 解出来是 /home，
            自己 encode 后拼回去得到 ?app1=/home&app2=%2Fhome
  app3 挂载 → 同理，前面两个都被降级

最终只有"最后挂载"的应用值是 encoded，其他全是 raw。多应用 sync 场景下
URL 携带的同步信息会损坏，刷新时按 URL 还原路由也会出错。

修复策略：约定 queryMap 内部值始终保持 decoded 形态，所有写回 URL 的地方
统一在 join 时 encodeURIComponent 一次：
  - syncUrlToWindow：set 时不再预 encode，写回时 encode
  - clearInactiveAppUrl：写回时把 decode 改成 encode（之前对已 decoded 的值 再做一次 decodeURIComponent，逻辑也是错的）
  - pushUrlToWindow：set 时不再预 encode，写回时 encode

processAppForHrefJump 内 decodeURIComponent(url) 对 decoded http URL 是幂等 no-op，保持不动以减少改动面。

同时 head.test.ts 在等到 mountedMessage 后立刻读 computed style 时存在 race （CSS 还没完成应用），与 host.test.ts 同位置对齐补 sleep(100)。

Made-with: Cursor

<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [ ] 提交符合commit规范
- [ ] 文档更改
- [ ] 测试用例添加
- [ ] `npm run test`通过

##### 详细描述

- 特性
- 关联issue
