### PR TITLE
fix(wujie-core): 修复 vite 多 css 场景下 insertAdjacentElement 创建的 style 缺失劫持

### DIFF
--- a/packages/wujie-core/__test__/unit/stylesheet-patch.test.ts
+++ b/packages/wujie-core/__test__/unit/stylesheet-patch.test.ts
@@ -1,0 +1,135 @@
+/**
+ * 关联 issue: https://github.com/Tencent/wujie/issues/1059
+ *
+ * 场景描述（vite dev server 的真实行为）：
+ *   第一个 css 通过 document.head.appendChild 插入；
+ *   后续每个 css 通过 lastInsertedStyle.insertAdjacentElement("afterend", style) 插入；
+ *   hot update 时直接 style.textContent = newContent。
+ *
+ * 之前实现里，被 insertAdjacentElement 插入的 style 只是触发了一次
+ * handleStylesheetElementPatch（提取 host/font 到 shadowRoot 外），
+ * 但 style 自身的 innerHTML / textContent / appendChild / sheet.insertRule
+ * 都未被劫持，导致：
+ *   1) 首次插入的 css 文本没有走 cssLoader（资源相对路径未转绝对）；
+ *   2) 后续 hot update 修改 textContent 时既不走 cssLoader 也不重新提取 font-face；
+ *   3) 如果再用该 style 链式 insertAdjacentElement，下游 style 直接走原生实现，
+ *      整条链路彻底脱离 wujie 接管。
+ *
+ * 本套用例用最小化 mock 覆盖以上 3 点，确保链式插入的每个 style 都获得
+ * 与第一个 style 完全一致的劫持能力。
+ */
+
+import { patchStylesheetElement } from "../../src/effect";
+
+interface FakeSandbox {
+  styleSheetElements: HTMLStyleElement[];
+  shadowRoot: { head: HTMLElement; host: HTMLElement };
+  degrade: boolean;
+}
+
+function createSandbox(): FakeSandbox {
+  return {
+    styleSheetElements: [],
+    shadowRoot: {
+      head: document.createElement("div"),
+      host: document.createElement("div"),
+    },
+    degrade: false,
+  };
+}
+
+const CUR_URL = "http://child-app.example.com/";
+
+describe("patchStylesheetElement / vite multi-style chain", () => {
+  let sandbox: FakeSandbox;
+  let cssLoader: jest.Mock;
+  let firstStyle: HTMLStyleElement;
+
+  beforeEach(() => {
+    document.head.innerHTML = "";
+    sandbox = createSandbox();
+    cssLoader = jest.fn((code: string) => `/* loaded */${code}`);
+    firstStyle = document.createElement("style");
+    document.head.appendChild(firstStyle);
+    patchStylesheetElement(firstStyle as any, cssLoader, sandbox as any, CUR_URL);
+  });
+
+  it("第二个 style 通过 insertAdjacentElement 插入时，其 innerHTML 必须经 cssLoader 改写", () => {
+    const second = document.createElement("style");
+    second.innerHTML = "@font-face{font-family:'t';src:url(./t.woff)}";
+
+    cssLoader.mockClear();
+    firstStyle.insertAdjacentElement("afterend", second);
+
+    expect(cssLoader).toHaveBeenCalledWith(
+      "@font-face{font-family:'t';src:url(./t.woff)}",
+      "",
+      CUR_URL
+    );
+    expect(sandbox.styleSheetElements).toContain(second);
+  });
+
+  it("第二个 style 后续 textContent 更新（vite hot update）应仍走 cssLoader", () => {
+    const second = document.createElement("style");
+    second.innerHTML = "body{color:red}";
+    firstStyle.insertAdjacentElement("afterend", second);
+
+    cssLoader.mockClear();
+    second.textContent = "@font-face{src:url(./b.woff)}";
+
+    expect(cssLoader).toHaveBeenCalledWith(
+      "@font-face{src:url(./b.woff)}",
+      "",
+      CUR_URL
+    );
+  });
+
+  it("第二个 style 后续 innerHTML 更新应仍走 cssLoader", () => {
+    const second = document.createElement("style");
+    second.innerHTML = "body{color:red}";
+    firstStyle.insertAdjacentElement("afterend", second);
+
+    cssLoader.mockClear();
+    second.innerHTML = "body{background:url(./bg.png)}";
+
+    expect(cssLoader).toHaveBeenCalledWith(
+      "body{background:url(./bg.png)}",
+      "",
+      CUR_URL
+    );
+  });
+
+  it("链式 insertAdjacentElement (second → third) 应递归保持劫持", () => {
+    const second = document.createElement("style");
+    second.innerHTML = "/* 2nd */";
+    firstStyle.insertAdjacentElement("afterend", second);
+
+    const third = document.createElement("style");
+    third.innerHTML = "@font-face{src:url(./c.woff)}";
+
+    cssLoader.mockClear();
+    second.insertAdjacentElement("afterend", third);
+
+    expect(cssLoader).toHaveBeenCalledWith(
+      "@font-face{src:url(./c.woff)}",
+      "",
+      CUR_URL
+    );
+    expect(sandbox.styleSheetElements).toContain(third);
+
+    // 第三个 style 的后续更新也必须被劫持
+    cssLoader.mockClear();
+    third.textContent = "/* 3rd updated */";
+    expect(cssLoader).toHaveBeenCalledWith("/* 3rd updated */", "", CUR_URL);
+  });
+
+  it("非 STYLE 节点走 insertAdjacentElement 不应进入劫持分支", () => {
+    const link = document.createElement("link");
+
+    cssLoader.mockClear();
+    firstStyle.insertAdjacentElement("afterend", link);
+
+    expect(cssLoader).not.toHaveBeenCalled();
+    expect(sandbox.styleSheetElements).not.toContain(link as any);
+  });
+});

--- a/packages/wujie-core/src/effect.ts
+++ b/packages/wujie-core/src/effect.ts
@@ -82,8 +82,9 @@ function handleStylesheetElementPatch(stylesheetElement: HTMLStyleElement & { _p
 
 /**
  * 劫持处理样式元素的属性
+ * @internal 仅出于可测性导出，外部不应直接调用
  */
-function patchStylesheetElement(
+export function patchStylesheetElement(
   stylesheetElement: HTMLStyleElement & { _hasPatchStyle?: boolean },
   cssLoader: (code: string, url: string, base: string) => string,
   sandbox: Wujie,
@@ -154,9 +155,25 @@ function patchStylesheetElement(
     insertAdjacentElement: {
       value: function (this: HTMLStyleElement, position: InsertPosition, element: Element) {
         if (element.nodeName === "STYLE") {
-          nextTick(() => handleStylesheetElementPatch(element as HTMLStyleElement, sandbox));
+          // 关联 issue: https://github.com/Tencent/wujie/issues/1059
+          //
+          // vite dev server 第一个 css 通过 head.appendChild 插入，后续每个 css 都走
+          // lastInsertedStyle.insertAdjacentElement("afterend", style)，hot update 时
+          // 直接 style.textContent = newContent。被 insertAdjacentElement 插入的 style
+          // 必须获得与"第一个 style"完全一致的劫持能力，否则：
+          //   1) 当前内容里的资源相对路径不会被 cssLoader 改写（@font-face 失效）；
+          //   2) 后续 textContent / innerHTML / appendChild / sheet.insertRule
+          //      绕过 wujie，hot update 全部脱管；
+          //   3) 链式 insertAdjacentElement 创建的下游 style 直接走原生实现。
+          // 因此这里必须复用与 case "STYLE" 完全一致的处理流程：先用 cssLoader 改写
+          // 当前内容，再 patchStylesheetElement 把劫持递归装到新 style 上。
+          const stylesheetElement = element as HTMLStyleElement;
+          const content = stylesheetElement.innerHTML;
+          if (content) stylesheetElement.innerHTML = cssLoader(content, "", curUrl);
           const res = rawInsertAdjacentElement.call(this, position, element);
-          sandbox.styleSheetElements.push(element as HTMLStyleElement);
+          sandbox.styleSheetElements.push(stylesheetElement);
+          patchStylesheetElement(stylesheetElement, cssLoader, sandbox, curUrl);
+          handleStylesheetElementPatch(stylesheetElement, sandbox);
           return res;
         } else return rawInsertAdjacentElement.call(this, position, element);
       },


### PR DESCRIPTION
Closes #1059
Supersedes #1060 （本 PR 合入后可关闭）

## 背景

vite dev server 的 `updateStyle` 逻辑大致如下：

```js
function updateStyle(id, content) {
  let style = sheetsMap.get(id);
  if (!style) {
    style = document.createElement("style");
    style.textContent = content;
    if (!lastInsertedStyle) {
      document.head.appendChild(style);                       // 第 1 个
    } else {
      lastInsertedStyle.insertAdjacentElement("afterend", style); // 第 2+ 个
    }
    lastInsertedStyle = style;
  } else {
    style.textContent = content;                              // hot update
  }
}
```

原实现里 `patchStylesheetElement` 仅对“第 1 个 style”装上完整劫持（`innerHTML` / `textContent` / `appendChild` / `sheet.insertRule` / `insertAdjacentElement` 5 个入口）。被 `insertAdjacentElement` 插入的 secondStyle 只触发了一次 `handleStylesheetElementPatch`（提取 host/font 到 shadowRoot 外），自身完全未被劫持。后果：

1. 当前 css 文本里的资源相对路径未走 `cssLoader` —— `@font-face` 的 `url(./xxx.woff)` 不会被转成绝对路径，字体加载 404；
2. vite hot update 走 `style.textContent = newContent`，后续修改不走 cssLoader、不重新提取 `@font-face`；
3. 链式 `secondStyle.insertAdjacentElement("afterend", thirdStyle)` 走原生实现，整条链路脱离 wujie 接管。

## 修复

在 `patchStylesheetElement` 内部的 `insertAdjacentElement` 分支跟 `case "STYLE"`（第 1 个 style 的处理路径）保持一致：先用 `cssLoader` 改写当前内容，再调 `patchStylesheetElement` 把完整劫持递归装到新 style 上。

- 首次插入时资源路径被改写、`@font-face` 正常提取；
- 后续 `textContent` / `innerHTML` / `appendChild` / `sheet.insertRule` 更新仍走 cssLoader；
- 链式 `insertAdjacentElement` 创建的下游 style 递归获得完整劫持。

## TDD

新增 `__test__/unit/stylesheet-patch.test.ts`，覆盖 5 个场景：

| # | 场景 | 修复前 | 修复后 |
|---|---|---|---|
| 1 | 首次 `insertAdjacentElement` 插入 → `innerHTML` 过 cssLoader | RED | GREEN |
| 2 | second style 后续 `textContent` 更新（hot update）走 cssLoader | RED | GREEN |
| 3 | second style 后续 `innerHTML` 更新走 cssLoader | RED | GREEN |
| 4 | 链式 second → third，third 也获完整劫持 | RED | GREEN |
| 5 | 非 STYLE 节点（`<link>`）不该进入劫持分支 | GREEN（反例防误伤） | GREEN |

## Test plan

- [x] `pnpm run test:unit` 本地全过：3 suites / 27 tests（新增 5 个）。
- [x] `lerna run prepack --scope wujie` webpack / babel / tsc declaration 全部编译成功。
- [ ] PR Tests workflow (#1078) 合入后本 PR 会自动跑 unit + integration。

## 备注

- 为 TDD 可测性需要将 `patchStylesheetElement` 从 module-private 提升为 `export`，已加 `@internal` 注释说明仅供测试导入。
- 与 #1060 差异：#1060 只复制了 `insertAdjacentElement` 一个方法与 `textContent` 一次改写，没能覆盖 hot update 场景；本 PR 在同方向上使用完整 `patchStylesheetElement` 递归，一次根治。