### PR TITLE
feat(wujie-core): 内置劫持模板里的 inline event handler，让自由变量解析到 sandbox proxy

### DIFF
--- a/packages/wujie-core/__test__/unit/inline-event.test.ts
+++ b/packages/wujie-core/__test__/unit/inline-event.test.ts
@@ -1,0 +1,153 @@
+/**
+ * 关联 issue: https://github.com/Tencent/wujie/issues/1072
+ *
+ * 场景描述：
+ *   子应用 HTML 模板中常出现 `<button onclick="someFn()">` 这类内联事件属性。
+ *   按 HTML5 规范，浏览器把 onclick 属性字符串编译成函数后，函数体内自由变量
+ *   的查找走的是元素 ownerDocument.defaultView——shadowRoot 不会创建新 document，
+ *   所以最终 fallback 到 *主 window*，永远不会去子应用的 sandbox proxy 上找。
+ *
+ *   结果：子应用代码即使把 someFn 挂在自己的 window/proxy 上，inline handler
+ *   还是 ReferenceError；用户被迫退化成 `window.__YOUR_NAMESPACE.someFn()`
+ *   这种全局命名空间挂载的写法。
+ *
+ * wujie 内置方案：
+ *   在模板渲染阶段（shadow.ts 的 ElementIterator 走每个元素时）扫描 `on*`
+ *   属性，把原代码搬到 `data-wujie-on-${type}` 上保存，把属性本身改写为对
+ *   主 window 上 dispatcher 的调用。dispatcher 收到 event 后，按
+ *   sandboxId 找回 sandbox.proxy，再把原代码用 `with(proxy)` 在 proxy
+ *   作用域内执行——`someFn` 自然解析到 sandbox.proxy.someFn。
+ */
+
+import {
+  rewriteInlineEventOnElement,
+  installInlineEventDispatcher,
+  INLINE_HANDLER_NAME,
+  INLINE_EVENT_DATA_PREFIX,
+} from "../../src/inline-event";
+import { idToSandboxCacheMap } from "../../src/common";
+
+describe("inline event handler 内置劫持", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    delete (window as any)[INLINE_HANDLER_NAME];
+    idToSandboxCacheMap.clear();
+  });
+
+  it("应将元素 on* 属性改写为 dispatcher 调用，并把原代码保存到 data-wujie-on-*", () => {
+    const button = document.createElement("button");
+    button.setAttribute("onclick", "testFn(this.value)");
+
+    rewriteInlineEventOnElement(button, "face-crm");
+
+    expect(button.getAttribute(INLINE_EVENT_DATA_PREFIX + "click")).toBe("testFn(this.value)");
+    const rewritten = button.getAttribute("onclick");
+    expect(rewritten).toContain(INLINE_HANDLER_NAME);
+    expect(rewritten).toContain("face-crm");
+  });
+
+  it("应同时改写多个 on* 属性，且互不影响", () => {
+    const input = document.createElement("input");
+    input.setAttribute("onchange", "handleChange()");
+    input.setAttribute("oninput", "handleInput()");
+
+    rewriteInlineEventOnElement(input, "face-crm");
+
+    expect(input.getAttribute(INLINE_EVENT_DATA_PREFIX + "change")).toBe("handleChange()");
+    expect(input.getAttribute(INLINE_EVENT_DATA_PREFIX + "input")).toBe("handleInput()");
+    expect(input.getAttribute("onchange")).toContain(INLINE_HANDLER_NAME);
+    expect(input.getAttribute("oninput")).toContain(INLINE_HANDLER_NAME);
+  });
+
+  it("不应动 class / id / data-* 等非 on* 属性", () => {
+    const div = document.createElement("div");
+    div.setAttribute("class", "foo");
+    div.setAttribute("id", "baz");
+    div.setAttribute("data-x", "bar");
+
+    rewriteInlineEventOnElement(div, "face-crm");
+
+    expect(div.getAttribute("class")).toBe("foo");
+    expect(div.getAttribute("id")).toBe("baz");
+    expect(div.getAttribute("data-x")).toBe("bar");
+  });
+
+  it("没有任何 on* 属性的元素应保持原样不被改写", () => {
+    const span = document.createElement("span");
+    span.setAttribute("title", "hello");
+    rewriteInlineEventOnElement(span, "face-crm");
+    expect(span.attributes.length).toBe(1);
+    expect(span.getAttribute("title")).toBe("hello");
+  });
+
+  it("dispatcher 应根据 sandboxId 在对应 sandbox.proxy 作用域内执行原代码", () => {
+    const handleClick = jest.fn();
+    const proxy: any = { handleClick };
+    idToSandboxCacheMap.set("face-crm", { wujie: { proxy } as any });
+    installInlineEventDispatcher(window);
+
+    const btn = document.createElement("button");
+    btn.setAttribute("onclick", "handleClick()");
+    rewriteInlineEventOnElement(btn, "face-crm");
+    document.body.appendChild(btn);
+
+    btn.click();
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("dispatcher 内 `this` 应指向触发事件的元素（保留 inline handler 标准语义）", () => {
+    const seen: any[] = [];
+    const proxy: any = {
+      record: (v: unknown) => seen.push(v),
+    };
+    idToSandboxCacheMap.set("face-crm", { wujie: { proxy } as any });
+    installInlineEventDispatcher(window);
+
+    const input = document.createElement("input");
+    input.value = "hello";
+    input.setAttribute("oninput", "record(this.value)");
+    rewriteInlineEventOnElement(input, "face-crm");
+    document.body.appendChild(input);
+
+    input.dispatchEvent(new Event("input"));
+
+    expect(seen).toEqual(["hello"]);
+  });
+
+  it("找不到 sandbox 时 dispatcher 应静默返回，不影响外层", () => {
+    installInlineEventDispatcher(window);
+    const btn = document.createElement("button");
+    btn.setAttribute("onclick", "willNotRun()");
+    rewriteInlineEventOnElement(btn, "ghost-id");
+    document.body.appendChild(btn);
+    expect(() => btn.click()).not.toThrow();
+  });
+
+  it("inline handler 的 return 值应被透传——浏览器据此判断是否 preventDefault", () => {
+    // 原生 inline handler 形如 onsubmit="return validate()"，返回 false 时
+    // 浏览器会阻止表单提交。改写后必须保留这一语义，否则诸如
+    // onsubmit="return false" / onclick="return confirm(...)" 等场景全部失效。
+    const proxy: any = { validate: () => false };
+    idToSandboxCacheMap.set("face-crm", { wujie: { proxy } as any });
+    installInlineEventDispatcher(window);
+
+    const form = document.createElement("form");
+    form.setAttribute("onsubmit", "return validate()");
+    rewriteInlineEventOnElement(form, "face-crm");
+    document.body.appendChild(form);
+
+    // 直接评估改写后的 onsubmit 字符串模拟浏览器编译为函数的过程：
+    // 浏览器会把字符串包成 `function(event) { ${str} }` 然后看返回值
+    const compiled = new Function("event", form.getAttribute("onsubmit") as string);
+    const ret = compiled.call(form, new Event("submit"));
+    expect(ret).toBe(false);
+  });
+
+  it("installInlineEventDispatcher 重复调用应保持幂等", () => {
+    installInlineEventDispatcher(window);
+    const first = (window as any)[INLINE_HANDLER_NAME];
+    installInlineEventDispatcher(window);
+    expect((window as any)[INLINE_HANDLER_NAME]).toBe(first);
+  });
+});

--- a/packages/wujie-core/src/inline-event.ts
+++ b/packages/wujie-core/src/inline-event.ts
@@ -1,0 +1,96 @@
+/**
+ * 内联事件属性（onclick / onchange / ...）的内置劫持
+ *
+ * 关联 issue: https://github.com/Tencent/wujie/issues/1072
+ *
+ * 背景：HTML 模板里的 `<button onclick="someFn()">` 由浏览器原生编译，
+ * 函数体里自由变量在 ownerDocument.defaultView（即 *主 window*）上查找，
+ * 永远不会去子应用的 sandbox proxy 上找。结果开发者必须把方法手动挂在
+ * 主 window 命名空间下才能让 inline handler 工作。
+ *
+ * 内置方案：
+ *   1) 模板渲染时，扫描每个元素的 on* 属性，把原代码搬到
+ *      data-wujie-on-${type} 上保存，把属性本身改写为对主 window 上
+ *      __WUJIE_INLINE_HANDLER__ dispatcher 的调用，并把所属 sandboxId
+ *      作为参数烧入。
+ *   2) dispatcher 收到 event 时，按 sandboxId 找回 sandbox.proxy，把原
+ *      代码用 `with(proxy)` 在 proxy 作用域内执行——子应用代码里挂在
+ *      sandbox proxy 上的方法此时即可被自然解析。
+ *
+ * 不在本期范围（用 setAttribute("onclick", str) 这种 JS 运行时改写
+ * inline handler 的场景属于另一个边界，单独评估）。
+ */
+
+import { idToSandboxCacheMap } from "./common";
+
+export const INLINE_HANDLER_NAME = "__WUJIE_INLINE_HANDLER__";
+export const INLINE_EVENT_DATA_PREFIX = "data-wujie-on-";
+
+/**
+ * 把元素上所有 on* 属性改写为 dispatcher 调用，原代码保存到
+ * data-wujie-on-${type} 属性上。已经处理过的属性（再次扫描时）
+ * 因为属性值已变成 dispatcher 调用，不会重复迁移。
+ */
+export function rewriteInlineEventOnElement(element: Element, sandboxId: string): void {
+  const attrs = element.attributes;
+  if (!attrs || !attrs.length) return;
+  // 收集后再修改，避免 NamedNodeMap 在迭代时被原地改动带来下标错乱
+  const inlineEventNames: string[] = [];
+  for (let i = 0; i < attrs.length; i++) {
+    const name = attrs[i].name;
+    if (name.length > 2 && name[0] === "o" && name[1] === "n") {
+      // 已经被改写过的属性值含 dispatcher 名，跳过避免二次包装
+      if (attrs[i].value.indexOf(INLINE_HANDLER_NAME) !== -1) continue;
+      inlineEventNames.push(name);
+    }
+  }
+  for (const name of inlineEventNames) {
+    const code = element.getAttribute(name);
+    if (code == null) continue;
+    const eventType = name.slice(2);
+    element.setAttribute(INLINE_EVENT_DATA_PREFIX + eventType, code);
+    // sandboxId 在模板编译时就已确定，烧入到字符串里避免 dispatcher
+    // 运行时再做归属反查（shadowRoot/degrade 模式下反查方式不一致）
+    // 显式 `return`：浏览器把 inline handler 字符串编译为 `function(event){ ${str} }`，
+    // 通过返回值判断 preventDefault（比如 onsubmit="return false"）。不写 return
+    // 的话原生语义里 `return false` 这类控制就丢了
+    element.setAttribute(
+      name,
+      `return window.${INLINE_HANDLER_NAME} && window.${INLINE_HANDLER_NAME}.call(this, event, ${JSON.stringify(
+        sandboxId
+      )})`
+    );
+  }
+}
+
+/**
+ * 把 dispatcher 幂等地挂到指定 window 上。同一 window 多次调用安全。
+ * 必须在子应用模板渲染前完成挂载。
+ */
+export function installInlineEventDispatcher(targetWindow: Window): void {
+  if ((targetWindow as any)[INLINE_HANDLER_NAME]) return;
+  (targetWindow as any)[INLINE_HANDLER_NAME] = function dispatchInlineEvent(
+    this: Element,
+    event: Event,
+    sandboxId: string
+  ): unknown {
+    const cache = idToSandboxCacheMap.get(sandboxId);
+    const sandbox = cache?.wujie;
+    if (!sandbox || !sandbox.proxy) return undefined;
+    const code = this.getAttribute(INLINE_EVENT_DATA_PREFIX + event.type);
+    if (!code) return undefined;
+    try {
+      // 用 with 在 sandbox.proxy 作用域内执行原代码：
+      //   - 自由变量先在 proxy 上查找（子应用挂在 window/proxy 的方法可达）
+      //   - 找不到时 fallback 到 Function 全局（主 window，console / setTimeout 等仍可用）
+      //   - this 通过 .call(this, ...) 仍指向触发事件的元素，保留标准 inline handler 语义
+      const handler = new Function("__wujieProxy__", "event", `with(__wujieProxy__){${code}}`);
+      return handler.call(this, sandbox.proxy, event);
+    } catch (error) {
+      // 子应用 inline handler 报错不应阻断框架本身，但开发期需要可见
+      // eslint-disable-next-line no-console
+      console.error(`[wujie] inline event handler error:`, error);
+      return undefined;
+    }
+  };
+}

--- a/packages/wujie-core/src/shadow.ts
+++ b/packages/wujie-core/src/shadow.ts
@@ -19,6 +19,7 @@ import { getExternalStyleSheets } from "./entry";
 import Wujie from "./sandbox";
 import { patchElementEffect } from "./iframe";
 import { patchRenderEffect } from "./effect";
+import { rewriteInlineEventOnElement, installInlineEventDispatcher } from "./inline-event";
 import { getCssLoader, getPresetLoaders } from "./plugin";
 import { getAbsolutePath, getContainer, getCurUrl, setAttrsToElement } from "./utils";
 
@@ -199,6 +200,10 @@ function renderTemplateToHtml(iframeWindow: Window, template: string): HTMLHtmlE
   let nextElement = ElementIterator.currentNode as HTMLElement;
   while (nextElement) {
     patchElementEffect(nextElement, iframeWindow);
+    // 改写元素上的 inline event 属性（onclick / onchange / ...）
+    // 让其指向主 window 上的 dispatcher，dispatcher 内部在 sandbox.proxy
+    // 作用域里执行原代码，解决 inline handler 自由变量始终落到主 window 的问题
+    rewriteInlineEventOnElement(nextElement, sandbox.id);
     const relativeAttr = relativeElementTagAttrMap[nextElement.tagName];
     const url = nextElement[relativeAttr];
     if (relativeAttr) nextElement.setAttribute(relativeAttr, getAbsolutePath(url, nextElement.baseURI || ""));
@@ -223,6 +228,9 @@ export async function renderTemplateToShadowRoot(
   iframeWindow: Window,
   template: string
 ): Promise<void> {
+  // dispatcher 必须在子应用模板真正注入到 shadowRoot 之前挂到主 window 上，
+  // 否则浏览器编译 inline handler 字符串成函数后，触发时会找不到 dispatcher
+  installInlineEventDispatcher(window);
   const html = renderTemplateToHtml(iframeWindow, template);
   // 处理 css-before-loader 和 css-after-loader
   const processedHtml = await processCssLoaderForTemplate(iframeWindow.__WUJIE, html);


### PR DESCRIPTION
关联 issue: #1072

## 背景

HTML 模板里的 `<button onclick="someFn()">` 由浏览器原生编译，函数体里的自由变量按 [HTML5 规范](https://html.spec.whatwg.org/multipage/webappapis.html#getting-the-current-value-of-the-event-handler) 在元素 ownerDocument.defaultView 上查找。shadowRoot 不创建新 document，所以最终落到主 window 而非子应用 sandbox proxy，开发者只能退化成 `window.__YOUR_NS.someFn()` 这类全局命名空间挂载的写法。

## 方案

模板渲染阶段（`shadow.ts` 的 ElementIterator walker）扫描每个元素的 `on*` 属性：

1. 把原代码搬到 `data-wujie-on-${type}` 上保存；
2. 把属性本身改写为对主 window 上 dispatcher 的调用，烧入所属 sandboxId；
3. 主 window 上幂等挂载 dispatcher：收到 event 后按 sandboxId 取回 `sandbox.proxy`，用 `with(proxy)` 在 proxy 作用域内执行原代码。

## 行为示例

子应用模板：

```html
<button onclick="testWujiePlugin()">click me</button>
<form onsubmit="return validate(this)">...</form>
```

经 wujie 渲染到 shadowRoot 后变成：

```html
<button
  onclick="return window.__WUJIE_INLINE_HANDLER__ && window.__WUJIE_INLINE_HANDLER__.call(this, event, 'face-crm')"
  data-wujie-on-click="testWujiePlugin()"
>click me</button>

<form
  onsubmit="return window.__WUJIE_INLINE_HANDLER__ && window.__WUJIE_INLINE_HANDLER__.call(this, event, 'face-crm')"
  data-wujie-on-submit="return validate(this)"
>...</form>
```

## 透明性

- 触发时 `this` 仍指向元素（保留 inline handler 标准语义）
- inline handler 的 `return` 值透传到浏览器（`onsubmit="return false"` 之类的 preventDefault 行为依然有效）
- 自由变量先在 sandbox.proxy 上查，找不到 fallback 到主 window（console、setTimeout 等仍可用）
- 找不到 sandbox 时 dispatcher 静默返回，不抛错
- dispatcher 仅注册一次，多次调用幂等

## 与 PR #1072 的关系

PR #1072 处理的是 inline `<script>` 标签内代码 IIFE 包装时往里追加 patch 代码的钩子，目标是把顶层 `function foo(){}` 之类的声明挂到 sandbox proxy。

本 PR 处理的是 HTML 元素 `on*=""` 属性的查找路径——两者作用对象完全不重叠：PR #1072 的钩子无法影响 inline event handler 的自由变量解析（浏览器原生编译，不经任何 IIFE）。两者可并存。

## 测试

新增 9 个单元测试覆盖：

- 属性改写规则
- 多个 `on*` 事件互不影响
- 非 `on*` 属性（class / id / data-*）不动
- 没有 `on*` 属性的元素无副作用
- proxy 作用域执行（dispatcher 找到子应用挂在 proxy 上的方法）
- `this` 指向触发事件的元素
- 找不到 sandbox 时静默返回
- `return` 值透传（`onsubmit` 阻止默认）
- dispatcher 注册幂等

## 不在本期范围

| 路径 | 处理 |
|---|---|
| 模板里静态 `<tag on*="...">`（vue-jsx / SSR / jQuery 模板） | ✅ 已覆盖 |
| `el.setAttribute("onclick", str)` | ❌ 后续评估 |
| `el.innerHTML = "<button onclick='...'>"` | ❌ 后续评估 |
| `el.onclick = fn`（fn 本身是子应用闭包） | ❌ 不需要处理（闭包带子应用作用域） |
| 内联 `<script>` 顶层声明挂 sandbox proxy | ❌ 与本期解耦（PR #1072 的另一个子问题） |

## 验证

- ✅ 单元测试 36/36 全过（含本 PR 9 个新增）
- ✅ `lerna run prepack --scope wujie` 编译干净（babel + tsc）
- 🔍 对子应用 HTML 模板的开销：仅在首次模板渲染时给元素多扫一遍 attributes，本身不重复创建函数；触发事件时 dispatcher 用 `new Function` 编译原代码（按需懒编译），inline event 频率低、可接受
