### PR TITLE
fix(core): 富文本编辑器跨 realm 与降级模式兼容

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -83,6 +83,12 @@ jobs:
       - name: Install dependencies
         run: pnpm i --filter "wujie-project" --filter "./packages/**" --filter "./examples/**" --frozen-lockfile
 
+      # pnpm 10 默认不执行依赖 lifecycle script，puppeteer 的 install.js 不会自动下载 Chromium；
+      # 根 package.json 已配置 onlyBuiltDependencies，此处再显式执行一次以兼容 CI 缓存恢复场景
+      - name: Install Puppeteer Chromium
+        working-directory: packages/wujie-core
+        run: pnpm run install-puppeteer-browser
+
       # examples 通过 main/module 字段引用 wujie / wujie-react / wujie-vue2 / wujie-vue3
       # 的 lib/esm 产物，这些目录由 prepack（build.sh）生成。CI 全新仓库没有产物，
       # 直接启动 dev server 会让主应用拿到空模块 → 页面空白 → 后续 selector 全找不到

--- a/examples/main-vue/src/App.vue
+++ b/examples/main-vue/src/App.vue
@@ -38,6 +38,7 @@
         <router-link to="/vue2-sub/dialog">dialog</router-link>
         <router-link to="/vue2-sub/location">location</router-link>
         <router-link to="/vue2-sub/communication">communication</router-link>
+        <router-link to="/vue2-sub/rich-text">富文本</router-link>
       </div>
       <!-- vue3相关路由 -->
       <router-link v-if="degrade" to="/vue3">

--- a/examples/main-vue/src/main.js
+++ b/examples/main-vue/src/main.js
@@ -18,6 +18,7 @@ import "ant-design-vue/es/tooltip/style/index.css";
 import "ant-design-vue/es/icon/style/index.css";
 import lifecycles from "./lifecycle";
 import plugins from "./plugin";
+import { wangEditorPlugin } from "./plugins/wangEditor";
 
 const isProduction = process.env.NODE_ENV === "production";
 const { setupApp, preloadApp, bus } = WujieVue;
@@ -86,6 +87,7 @@ setupApp({
   exec: true,
   props,
   fetch: credentialsFetch,
+  plugins: [wangEditorPlugin],
   degrade,
   ...lifecycles,
 });

--- a/examples/main-vue/src/main.js
+++ b/examples/main-vue/src/main.js
@@ -98,7 +98,7 @@ setupApp({
   attrs,
   exec: true,
   destroyOnUnmount: true,
-  // alive: true,
+  alive: true,
   plugins: [{ cssExcludes: ["https://stackpath.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"] }],
   props,
   // 引入了的第三方样式不需要添加credentials

--- a/examples/main-vue/src/plugins/wangEditor.js
+++ b/examples/main-vue/src/plugins/wangEditor.js
@@ -1,0 +1,35 @@
+/**
+ * wangEditor 在无界下的兼容插件（Issue #479）。
+ *
+ * 子应用 UI 在主应用 shadowRoot 中渲染，paste 事件的 clipboardData 来自主应用 realm，
+ * 子应用内 `clipboardData instanceof DataTransfer` 会为 false，导致粘贴无响应。
+ *
+ * 非降级模式可由 wujie-core 的 patchInstanceofAcrossRealms 修复 DataTransfer；
+ * 降级模式需在此显式对齐 Selection / DataTransfer 构造函数。
+ */
+export const wangEditorPlugin = {
+  jsBeforeLoaders: [
+    {
+      callback(appWindow) {
+        Object.defineProperties(appWindow, {
+          Selection: {
+            configurable: true,
+            get() {
+              return appWindow.__WUJIE.degrade
+                ? appWindow.__WUJIE.document.defaultView.Selection
+                : appWindow.parent.Selection;
+            },
+          },
+          DataTransfer: {
+            configurable: true,
+            get() {
+              return appWindow.__WUJIE.degrade
+                ? appWindow.__WUJIE.document.defaultView.DataTransfer
+                : appWindow.parent.DataTransfer;
+            },
+          },
+        });
+      },
+    },
+  ],
+};

--- a/examples/vue2/.gitignore
+++ b/examples/vue2/.gitignore
@@ -2,6 +2,9 @@
 node_modules
 /dist
 
+# 由 scripts/copy-tinymce.js 生成的本地自托管 TinyMCE 资源
+/public/tinymce
+
 
 # local env files
 .env.local

--- a/examples/vue2/package.json
+++ b/examples/vue2/package.json
@@ -3,17 +3,22 @@
   "version": "2.0.0",
   "private": true,
   "scripts": {
+    "prestart": "node scripts/copy-tinymce.js",
     "start": "vue-cli-service serve --mode:development",
+    "prebuild": "node scripts/copy-tinymce.js",
     "build": "export NODE_OPTIONS=--openssl-legacy-provider && vue-cli-service build",
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
     "@floating-ui/dom": "0.5.4",
     "@popperjs/core": "2.11.8",
+    "@wangeditor/editor": "^5.1.23",
+    "@wangeditor/editor-for-vue": "^1.0.2",
     "ant-design-vue": "1.7.8",
     "core-js": "^3.6.5",
     "element-ui": "2.15.6",
     "popper.js": "1.16.1",
+    "tinymce": "^6.8.5",
     "vue": "^2.6.11",
     "vue-router": "^3.2.0"
   },

--- a/examples/vue2/public/index.html
+++ b/examples/vue2/public/index.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
+    <script src="<%= BASE_URL %>tinymce/tinymce.min.js"></script>
     <title><%= htmlWebpackPlugin.options.title %></title>
   </head>
   <body>

--- a/examples/vue2/scripts/copy-tinymce.js
+++ b/examples/vue2/scripts/copy-tinymce.js
@@ -1,0 +1,22 @@
+/* eslint-disable */
+// 将本地 node_modules/tinymce 的静态资源拷贝到 public/tinymce，
+// 供 dev server / 构建产物以 /tinymce 路径静态托管。
+// 这样 TinyMCE 可在运行时通过 base_url 用动态 <link> 加载 skin.min.css，
+// 用于验证无界对“先 appendChild 再 setAttribute href”这类 link 的修复。
+const fs = require("fs");
+const path = require("path");
+
+const force = process.argv.includes("--force");
+const pkgRoot = path.dirname(require.resolve("tinymce/package.json"));
+const dest = path.join(__dirname, "..", "public", "tinymce");
+const flagFile = path.join(dest, "tinymce.min.js");
+
+if (!force && fs.existsSync(flagFile)) {
+  console.log("[copy-tinymce] public/tinymce 已存在，跳过拷贝（--force 可强制覆盖）。");
+  process.exit(0);
+}
+
+console.log(`[copy-tinymce] 从 ${pkgRoot} 拷贝到 ${dest} ...`);
+fs.rmSync(dest, { recursive: true, force: true });
+fs.cpSync(pkgRoot, dest, { recursive: true, dereference: true });
+console.log("[copy-tinymce] 拷贝完成。");

--- a/examples/vue2/src/App.vue
+++ b/examples/vue2/src/App.vue
@@ -2,7 +2,8 @@
   <div id="app">
     <div id="nav" v-if="$route.name !== 'postmessage'">
       <router-link to="/home">首页</router-link> | <router-link to="/dialog">弹窗</router-link> |
-      <router-link to="/location">路由</router-link> | <router-link to="/communication">通信</router-link>
+      <router-link to="/location">路由</router-link> | <router-link to="/communication">通信</router-link> |
+      <router-link to="/rich-text">富文本</router-link>
     </div>
     <router-view />
   </div>

--- a/examples/vue2/src/components/rich-text/TinyMceDemoBlock.vue
+++ b/examples/vue2/src/components/rich-text/TinyMceDemoBlock.vue
@@ -1,0 +1,126 @@
+<template>
+  <section class="issue-block">
+    <h3>{{ title }}</h3>
+    <el-alert :closable="false" show-icon :type="alertType" class="issue-alert">
+      <div slot="title">{{ issueLabel }}</div>
+      <p class="issue-desc">{{ description }}</p>
+      <p class="issue-steps">{{ steps }}</p>
+      <a class="issue-link" :href="issueUrl" target="_blank" rel="noopener noreferrer">{{ issueUrl }}</a>
+    </el-alert>
+
+    <div class="tinymce-host">
+      <textarea ref="editorHost" class="tinymce-textarea"></textarea>
+    </div>
+    <p v-if="ready" class="init-ok">编辑器与皮肤已正常加载。</p>
+    <p v-if="initError" class="init-error">{{ initError }}</p>
+  </section>
+</template>
+
+<script>
+import hostMap from "@/hostMap";
+
+export default {
+  name: "TinyMceDemoBlock",
+  props: {
+    title: { type: String, required: true },
+    issueLabel: { type: String, required: true },
+    issueUrl: { type: String, required: true },
+    description: { type: String, required: true },
+    steps: { type: String, required: true },
+    alertType: { type: String, default: "info" },
+  },
+  data() {
+    return {
+      editor: null,
+      ready: false,
+      initError: "",
+    };
+  },
+  mounted() {
+    this.initEditor();
+  },
+  beforeDestroy() {
+    this.destroyEditor();
+  },
+  methods: {
+    async initEditor() {
+      try {
+        const tinymce = window.tinymce;
+        if (!tinymce) {
+          throw new Error("未找到 window.tinymce，请确认 public/tinymce/tinymce.min.js 已正确加载");
+        }
+
+        const host = hostMap("//localhost:7200/");
+        const editors = await tinymce.init({
+          target: this.$refs.editorHost,
+          height: 320,
+          menubar: false,
+          branding: false,
+          promotion: false,
+          skin_url: `${host}tinymce/skins/ui/oxide`,
+          content_css: `${host}tinymce/skins/content/default/content.min.css`,
+          plugins: "lists link",
+          toolbar: "undo redo | bold italic | bullist numlist | link",
+        });
+        this.editor = Array.isArray(editors) ? editors[0] : editors;
+        this.ready = true;
+      } catch (err) {
+        this.initError = `TinyMCE 初始化失败：${err?.message || err}`;
+      }
+    },
+    destroyEditor() {
+      if (this.editor) {
+        this.editor.destroy();
+        this.editor = null;
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+.issue-block {
+  margin-bottom: 40px;
+}
+
+.issue-block h3 {
+  margin: 0 0 12px;
+  font-size: 16px;
+}
+
+.issue-alert {
+  margin-bottom: 12px;
+}
+
+.issue-desc,
+.issue-steps {
+  margin: 6px 0;
+  line-height: 1.5;
+  font-size: 14px;
+}
+
+.issue-link {
+  font-size: 13px;
+  word-break: break-all;
+}
+
+.tinymce-host {
+  min-height: 320px;
+}
+
+.tinymce-textarea {
+  width: 100%;
+  min-height: 280px;
+}
+
+.init-ok {
+  margin-top: 10px;
+  color: #67c23a;
+  font-size: 13px;
+}
+
+.init-error {
+  color: #f56c6c;
+  font-size: 13px;
+}
+</style>

--- a/examples/vue2/src/components/rich-text/WangEditorDemoBlock.vue
+++ b/examples/vue2/src/components/rich-text/WangEditorDemoBlock.vue
@@ -1,0 +1,236 @@
+<template>
+  <section class="issue-block">
+    <h3>{{ title }}</h3>
+    <el-alert :closable="false" show-icon :type="alertType" class="issue-alert">
+      <div slot="title">{{ issueLabel }}</div>
+      <p class="issue-desc">{{ description }}</p>
+      <p class="issue-steps">{{ steps }}</p>
+      <a class="issue-link" :href="issueUrl" target="_blank" rel="noopener noreferrer">{{ issueUrl }}</a>
+    </el-alert>
+    <div v-if="showSelectionPanel || showLoRoPanel" class="selection-panel">
+      <template v-if="showSelectionPanel">
+        <p><strong>Selection.isCollapsed</strong>（编辑时实时刷新）</p>
+        <p class="selection-hint">光标折叠时应为 <code>true</code>，拖选文字时应为 <code>false</code>。</p>
+        <pre>{{ selectionDebug }}</pre>
+        <p v-if="selectionOk" class="selection-ok">isCollapsed 表现正常</p>
+      </template>
+      <template v-if="showLoRoPanel">
+        <p><strong>wangEditor LO / RO</strong>（#513 降级快速输入）</p>
+        <p class="selection-hint">
+          <code>LO</code> / <code>RO</code> 为 true 时 Slate 选区同步正常；快速输入时若变为 false 易失焦。
+        </p>
+        <pre>{{ loRoDebug }}</pre>
+        <p v-if="loRoOk" class="selection-ok">LO / RO 校验通过</p>
+      </template>
+    </div>
+    <div class="editor-shell">
+      <Toolbar v-if="editor" :editor="editor" :defaultConfig="toolbarConfig" mode="default" />
+      <Editor
+        v-model="html"
+        class="wang-editor-body"
+        :style="{ height: editorHeight }"
+        :defaultConfig="editorConfig"
+        :mode="mode"
+        @onCreated="onCreated"
+        @onChange="refreshSelection"
+        @onFocus="refreshSelection"
+        @onBlur="refreshSelection"
+      />
+    </div>
+    <p v-if="!showSelectionPanel" class="init-ok">编辑器已正常加载，上述场景验证通过。</p>
+  </section>
+</template>
+
+<script>
+import { Editor, Toolbar } from "@wangeditor/editor-for-vue";
+import "@wangeditor/editor/dist/css/style.css";
+
+export default {
+  name: "WangEditorDemoBlock",
+  components: { Editor, Toolbar },
+  props: {
+    title: { type: String, required: true },
+    issueLabel: { type: String, required: true },
+    issueUrl: { type: String, required: true },
+    description: { type: String, required: true },
+    steps: { type: String, required: true },
+    initialHtml: { type: String, default: "" },
+    showSelectionPanel: { type: Boolean, default: false },
+    showLoRoPanel: { type: Boolean, default: false },
+    editorHeight: { type: String, default: "220px" },
+    alertType: { type: String, default: "success" },
+  },
+  data() {
+    return {
+      editor: null,
+      html: this.initialHtml,
+      mode: "default",
+      toolbarConfig: {},
+      editorConfig: {
+        placeholder: "请在此输入内容进行验证…",
+      },
+      selectionDebug: "（尚未聚焦编辑器）",
+      selectionOk: false,
+      loRoDebug: "（尚未聚焦编辑器）",
+      loRoOk: false,
+    };
+  },
+  watch: {
+    initialHtml(val) {
+      if (val !== this.html) {
+        this.html = val;
+      }
+    },
+  },
+  mounted() {
+    if (this.showSelectionPanel || this.showLoRoPanel) {
+      this.onSelectionChange = () => this.refreshSelection();
+      document.addEventListener("selectionchange", this.onSelectionChange);
+    }
+  },
+  beforeDestroy() {
+    if (this.onSelectionChange) {
+      document.removeEventListener("selectionchange", this.onSelectionChange);
+      this.onSelectionChange = null;
+    }
+    if (this.editor) {
+      this.editor.destroy();
+      this.editor = null;
+    }
+  },
+  methods: {
+    onCreated(editor) {
+      this.editor = Object.seal(editor);
+    },
+    refreshSelection() {
+      const selection = window.getSelection();
+      if (this.showSelectionPanel) {
+        if (!selection || selection.rangeCount === 0) {
+          this.selectionDebug = "getSelection() 为空或 rangeCount = 0";
+          this.selectionOk = false;
+        } else {
+          const range = selection.getRangeAt(0);
+          const collapsedByOffset =
+            selection.anchorNode === selection.focusNode && selection.anchorOffset === selection.focusOffset;
+          this.selectionOk = selection.isCollapsed === collapsedByOffset;
+          this.selectionDebug = JSON.stringify(
+            {
+              isCollapsed: selection.isCollapsed,
+              anchorOffset: selection.anchorOffset,
+              focusOffset: selection.focusOffset,
+              rangeCollapsed: range.collapsed,
+              collapsedByOffset,
+              inWujie: Boolean(window.__POWERED_BY_WUJIE__),
+              degrade: Boolean(window.__WUJIE?.degrade),
+            },
+            null,
+            2
+          );
+        }
+      }
+      if (this.showLoRoPanel) {
+        this.refreshLoRo(selection);
+      }
+    },
+    refreshLoRo(selection) {
+      if (!selection || selection.rangeCount === 0) {
+        this.loRoDebug = "getSelection() 为空或 rangeCount = 0";
+        this.loRoOk = false;
+        return;
+      }
+      const NO = (node) => node?.ownerDocument?.defaultView || null;
+      const LO = (node) => {
+        const view = NO(node);
+        return Boolean(view && node instanceof view.Node);
+      };
+      const RO = (sel) => {
+        const view = sel?.anchorNode && NO(sel.anchorNode);
+        return Boolean(view && sel instanceof view.Selection);
+      };
+      const renderDoc = window.__WUJIE?.document;
+      const anchor = selection.anchorNode;
+      const focus = selection.focusNode;
+      this.loRoOk = RO(selection) && LO(anchor) && LO(focus);
+      this.loRoDebug = JSON.stringify(
+        {
+          RO: RO(selection),
+          LO_anchor: LO(anchor),
+          LO_focus: LO(focus),
+          anchorOwnerIsRenderDoc: Boolean(renderDoc && anchor?.ownerDocument === renderDoc),
+          focusOwnerIsRenderDoc: Boolean(renderDoc && focus?.ownerDocument === renderDoc),
+          degrade: Boolean(window.__WUJIE?.degrade),
+          inWujie: Boolean(window.__POWERED_BY_WUJIE__),
+        },
+        null,
+        2
+      );
+    },
+  },
+};
+</script>
+
+<style scoped>
+.issue-block {
+  margin-bottom: 40px;
+}
+
+.issue-block h3 {
+  margin: 0 0 12px;
+  font-size: 16px;
+}
+
+.issue-alert {
+  margin-bottom: 12px;
+}
+
+.issue-desc,
+.issue-steps {
+  margin: 6px 0;
+  line-height: 1.5;
+  font-size: 14px;
+}
+
+.issue-link {
+  font-size: 13px;
+  word-break: break-all;
+}
+
+.selection-panel {
+  margin-bottom: 12px;
+  padding: 10px 12px;
+  background: #f6f8fa;
+  border-radius: 4px;
+  font-size: 13px;
+}
+
+.selection-hint {
+  margin: 6px 0;
+  color: #606266;
+  line-height: 1.5;
+}
+
+.selection-panel pre {
+  margin: 8px 0 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.selection-ok {
+  margin: 8px 0 0;
+  color: #67c23a;
+}
+
+.editor-shell {
+  border: 1px solid #e8e8e8;
+}
+
+.wang-editor-body {
+  overflow-y: hidden;
+}
+
+.init-ok {
+  margin-top: 10px;
+  color: #67c23a;
+  font-size: 13px;
+}
+</style>

--- a/examples/vue2/src/main.js
+++ b/examples/vue2/src/main.js
@@ -10,6 +10,11 @@ import Select from "element-ui/lib/select";
 import Option from "element-ui/lib/option";
 import Popover from "element-ui/lib/popover";
 import Dialog from "element-ui/lib/dialog";
+import Tabs from "element-ui/lib/tabs";
+import TabPane from "element-ui/lib/tab-pane";
+import Collapse from "element-ui/lib/collapse";
+import CollapseItem from "element-ui/lib/collapse-item";
+import Alert from "element-ui/lib/alert";
 import AButton from "ant-design-vue/es/button";
 import ASelect from "ant-design-vue/es/select";
 import AModal from "ant-design-vue/es/modal";
@@ -22,6 +27,11 @@ import "element-ui/lib/theme-chalk/select.css";
 import "element-ui/lib/theme-chalk/option.css";
 import "element-ui/lib/theme-chalk/popover.css";
 import "element-ui/lib/theme-chalk/dialog.css";
+import "element-ui/lib/theme-chalk/tabs.css";
+import "element-ui/lib/theme-chalk/tab-pane.css";
+import "element-ui/lib/theme-chalk/collapse.css";
+import "element-ui/lib/theme-chalk/collapse-item.css";
+import "element-ui/lib/theme-chalk/alert.css";
 import "ant-design-vue/es/style/index.css";
 import "ant-design-vue/es/button/style/index.css";
 import "ant-design-vue/es/select/style/index.css";
@@ -31,7 +41,9 @@ import "./index.css";
 
 const base = process.env.NODE_ENV === "production" ? "/demo-vue2/" : "";
 
-[Tag, Button, Select, Option, Popover, Dialog].forEach((element) => Vue.use(element));
+[Tag, Button, Select, Option, Popover, Dialog, Tabs, TabPane, Collapse, CollapseItem, Alert].forEach(
+  (element) => Vue.use(element)
+);
 [AButton, ASelect, AModal, APopover].forEach((element) => Vue.use(element));
 
 Vue.use(VueRouter);

--- a/examples/vue2/src/router/index.js
+++ b/examples/vue2/src/router/index.js
@@ -29,6 +29,11 @@ const routes = [
     name: "postmessage",
     component: () => import(/* webpackChunkName: "Page3" */ "../views/PostMessage.vue"),
   },
+  {
+    path: "/rich-text",
+    name: "rich-text",
+    component: () => import(/* webpackChunkName: "RichText" */ "../views/RichText.vue"),
+  },
 ];
 
 export default routes;

--- a/examples/vue2/src/views/RichText.vue
+++ b/examples/vue2/src/views/RichText.vue
@@ -1,0 +1,129 @@
+<template>
+  <div class="rich-text-page">
+    <HelloWorld msg="富文本"></HelloWorld>
+    <div class="content">
+      <p class="intro">
+        对照
+        <a href="https://github.com/Tencent/wujie/issues" target="_blank" rel="noopener noreferrer">wujie Issues</a>
+        中 wangEditor / TinyMCE
+        的常见问题。建议在<strong>无界主应用嵌入子应用</strong>与<strong>子应用单独打开</strong>两种环境下分别验证。
+      </p>
+      <el-tag v-if="inWujie" type="warning" size="small">当前运行在无界子应用环境</el-tag>
+      <el-tag v-else type="success" size="small">当前为子应用独立运行</el-tag>
+
+      <el-tabs v-model="activeTab" class="editor-tabs">
+        <el-tab-pane label="wangEditor" name="wangEditor">
+          <WangEditorDemoBlock
+            title="预填内容删改（#218）"
+            issue-label="已验证 · Issue #218"
+            issue-url="https://github.com/Tencent/wujie/issues/218"
+            description="子应用使用 wangEditor 初始化已有 HTML 后，聚焦编辑、删除预填文字、在中段插入内容均正常。"
+            steps="操作：点击下方编辑器，删除预填文字或在「预填」二字前插入新内容，确认光标与删改行为符合预期。"
+            :initial-html="wangPrefillHtml"
+            editor-height="240px"
+            alert-type="success"
+          />
+          <WangEditorDemoBlock
+            title="快速输入不失焦（#513）"
+            issue-label="已验证 · Issue #513"
+            issue-url="https://github.com/Tencent/wujie/issues/513"
+            description="wangEditor 5.x 在无界环境（含降级）下快速连续输入时编辑器保持聚焦。框架侧：getSelection / ownerDocument 指向渲染 iframe，patchDegradeInstanceofAcrossRealms 修复跨 iframe instanceof。"
+            steps="操作：建议在主应用降级模式下验证——在下方编辑器快速连续打字（含输入法），确认无失焦、光标跳动；可选观察上方 LO/RO 面板均为 true。"
+            editor-height="200px"
+            :show-lo-ro-panel="true"
+            alert-type="success"
+          />
+          <WangEditorDemoBlock
+            title="Selection / DOM 一致（#450、#770）"
+            issue-label="已验证 · Issue #450、#770"
+            issue-url="https://github.com/Tencent/wujie/issues/450"
+            description="选区与 DOM 映射正常，无 Cannot resolve a Slate range from DOM range；getSelection() 指向正确的 document / shadowRoot。"
+            steps="操作：在编辑器中点击、选中文字并编辑，确认无控制台报错，选区行为正常。"
+            editor-height="220px"
+            alert-type="success"
+          />
+          <WangEditorDemoBlock
+            title="复制粘贴（#479）"
+            issue-label="已验证 · Issue #479"
+            issue-url="https://github.com/Tencent/wujie/issues/479"
+            description="paste 事件的 clipboardData 来自主应用 realm，需修复 DataTransfer 的 instanceof 跨 realm 判断；否则复制正常但粘贴进编辑器无响应。"
+            steps="操作：在下方编辑器中选中文字 Ctrl+C，再 Ctrl+V 粘贴；或从外部复制一段文字后粘贴进编辑器，确认内容出现。"
+            :initial-html="wangPasteHtml"
+            editor-height="200px"
+            alert-type="success"
+          />
+          <WangEditorDemoBlock
+            title="isCollapsed 判断正常（#489 等）"
+            issue-label="已验证 · Selection.isCollapsed"
+            issue-url="https://github.com/Tencent/wujie/issues/489"
+            description="无界环境下 Selection.isCollapsed 不再恒为 true：仅光标折叠时为 true，拖选文字时为 false。该问题曾导致 wangEditor 误判选区、删改与粘贴异常。"
+            steps="操作：点击编辑器定位光标，确认 isCollapsed 为 true；再拖选一段文字，确认 isCollapsed 变为 false，且与 anchor/focus 偏移一致。"
+            :initial-html="wangSelectionHtml"
+            :show-selection-panel="true"
+            editor-height="200px"
+            alert-type="success"
+          />
+        </el-tab-pane>
+
+        <el-tab-pane label="TinyMCE" name="tinymce">
+          <TinyMceDemoBlock
+            title="本地自托管 TinyMCE：显式配置 skin_url / content_css（#224 / #974）"
+            issue-label="关联 Issue #224、#974"
+            issue-url="https://github.com/Tencent/wujie/issues/974"
+            description="不使用远端 CDN，直接加载本地 public/tinymce/tinymce.min.js，并在 init 时按 TinyMCE 常规接入方式显式配置 skin_url 和 content_css。"
+            steps="验证：下方编辑器若能完整显示 oxide 皮肤（工具栏、边框、编辑区样式齐全），说明 TinyMCE 的皮肤与内容样式在无界子应用内都能正常加载。可在 Network 过滤 tinymce / skin 确认资源请求。"
+            alert-type="success"
+          />
+        </el-tab-pane>
+      </el-tabs>
+    </div>
+  </div>
+</template>
+
+<script>
+import HelloWorld from "@/components/HelloWorld.vue";
+import WangEditorDemoBlock from "@/components/rich-text/WangEditorDemoBlock.vue";
+import TinyMceDemoBlock from "@/components/rich-text/TinyMceDemoBlock.vue";
+
+const WANG_PREFILL_HTML =
+  "<p>这是<strong>预填内容</strong>，请尝试删除本段文字或在「预填」二字前插入新内容。</p>";
+
+const WANG_SELECTION_HTML =
+  "<p>请<strong>拖选这段文字</strong>，观察上方 isCollapsed 从 true 变为 false。</p>";
+
+const WANG_PASTE_HTML =
+  "<p>请选中本段文字并复制，再粘贴到下方空白处；或从外部复制文字后粘贴到此处。</p>";
+
+export default {
+  name: "RichText",
+  components: {
+    HelloWorld,
+    WangEditorDemoBlock,
+    TinyMceDemoBlock,
+  },
+  data() {
+    return {
+      activeTab: "wangEditor",
+      wangPrefillHtml: WANG_PREFILL_HTML,
+      wangSelectionHtml: WANG_SELECTION_HTML,
+      wangPasteHtml: WANG_PASTE_HTML,
+      inWujie: Boolean(window.__POWERED_BY_WUJIE__),
+    };
+  },
+};
+</script>
+
+<style scoped>
+.rich-text-page .content {
+  max-width: 900px;
+}
+
+.intro {
+  line-height: 1.6;
+  margin-bottom: 12px;
+}
+
+.editor-tabs {
+  margin-top: 20px;
+}
+</style>

--- a/notes/rich-text-editors-issues.md
+++ b/notes/rich-text-editors-issues.md
@@ -1,0 +1,199 @@
+# wujie 富文本 / 文档编辑器相关 Issue 调研
+
+> 基于对 [Tencent/wujie](https://github.com/Tencent/wujie) Issues 的多轮 GitHub API 检索整理（关键词：富文本、各编辑器库名、`getSelection` 等）。
+>
+> 检索时间：2026-06。仓库当前约 **461** 个 Open Issue；按「明确提到编辑器」口径，富文本相关约占 **3%～5%**。
+
+---
+
+## TL;DR
+
+1. 去重后约 **21 条**明确与富文本/文档编辑器相关的 Issue（Open ~16，Closed ~5），涉及 **9 类**编辑器/库（wangEditor 族算 1 类）。
+2. **wangEditor** 相关最多（约 12+ 条），共性根因集中在 `getSelection()` 代理、`instanceof Node` 跨 realm、`isCollapsed` 失真、事件 target 指向 `WUJIE-APP`、降级与非降级行为差异。
+3. **TinyMCE** 的 `#224` / `#974` 为同一问题重复上报（skin.min.css 未加载）；**框架层** `#770`（多子应用 `getSelection()` 指向第一个 shadowRoot）与大量富文本 issue 高度相关。
+4. 社区常用缓解：`wujie-polyfill`、自定义 `plugins`（`jsBeforeLoaders` / `jsLoader`）、wangEditor 官方微前端 iframe 沙箱 PR、已合并的 `#792` 全局对象缓存修复。
+
+---
+
+## 统计概览
+
+| 维度 | 数量 |
+| --- | --- |
+| 明确与富文本/文档编辑器相关的 Issue（去重后） | 约 21 条 |
+| 其中 Open | 约 16 条 |
+| 其中 Closed | 约 5 条 |
+| 涉及不同编辑器/库 | 9 类（wangEditor 族算 1 类） |
+
+### 计数说明
+
+- [#224](https://github.com/Tencent/wujie/issues/224) 与 [#974](https://github.com/Tencent/wujie/issues/974) 为同一 TinyMCE 问题重复上报，计数时算 **2 条 issue、1 类问题**。
+- [#791](https://github.com/Tencent/wujie/issues/791)、[#656](https://github.com/Tencent/wujie/issues/656)、[#598](https://github.com/Tencent/wujie/issues/598) 偏方案汇总/经验贴，仍计入富文本相关。
+- [#770](https://github.com/Tencent/wujie/issues/770) 为框架层 `getSelection()` 问题，但大量富文本 issue 的根因与此相关，单独列出。
+- **未计入**：[#996](https://github.com/Tencent/wujie/issues/996)（主诉子应用空白 div，仅代码里出现 Quill）、[#256](https://github.com/Tencent/wujie/issues/256)（通用 `instanceof`，非专指富文本）。
+
+---
+
+## 按富文本库分类清单
+
+### 1. wangEditor / @wangeditor（最多，约 12+ 条）
+
+| Issue | 状态 | 问题摘要 |
+| --- | --- | --- |
+| [#479](https://github.com/Tencent/wujie/issues/479) | Closed | wangEditor 无法修改/复制粘贴；Quill 工具栏报错 |
+| [#489](https://github.com/Tencent/wujie/issues/489) | Closed | 降级模式 `degrade: true` 下无法复制粘贴，光标总在首位 |
+| [#218](https://github.com/Tencent/wujie/issues/218) | Open | 无法修改已有内容，聚焦后不能删除 |
+| [#450](https://github.com/Tencent/wujie/issues/450) | Open | `Cannot resolve a Slate range from DOM range`，疑似走了主应用 document |
+| [#513](https://github.com/Tencent/wujie/issues/513) | Open | v5.1.23 快速输入失焦（含 plugins workaround） |
+| [#598](https://github.com/Tencent/wujie/issues/598) | Open | 降级模式 plugins 处理方案（非降级不适用） |
+| [#638](https://github.com/Tencent/wujie/issues/638) | Open | Safari 下 `jsBeforeLoader` 偶发不执行（wangEditor 适配分支） |
+| [#656](https://github.com/Tencent/wujie/issues/656) | Open | vue2+vite：子应用 index.html 引入；主应用注册会导致图片无法拖拽缩放 |
+| [#791](https://github.com/Tencent/wujie/issues/791) | Open | wangEditor/Slate 方案汇总（wujie-polyfill、patch 等） |
+| [#906](https://github.com/Tencent/wujie/issues/906) | Open | 基座 Vue3 + 子应用 Vue2，编辑区无法操作 |
+| [#933](https://github.com/Tencent/wujie/issues/933) | Open | @wangeditor-next 全屏仅子应用内，无法盖住主应用（fixed 局限） |
+
+**共性根因（社区讨论）：** Selection / `getSelection()` 代理、`instanceof Node`、`isCollapsed` 判断、事件 target 指向 `WUJIE-APP`、降级与非降级行为差异。
+
+---
+
+### 2. TinyMCE（2 条，同一问题）
+
+| Issue | 状态 | 问题摘要 |
+| --- | --- | --- |
+| [#224](https://github.com/Tencent/wujie/issues/224) | Open | 子应用内未加载 `skin.min.css`，编辑器不显示 |
+| [#974](https://github.com/Tencent/wujie/issues/974) | Open | 同上（较新重复 issue） |
+
+**根因方向：** script 加载 + `tinymce.init` 时，子应用环境未自动注入皮肤 CSS；部分库会先 `appendChild(link)` 再设置 `href`，需 wujie 对延迟 href 的 `<link>` 做监听处理。相对路径可能被解析到主应用 origin，init 时建议使用绝对地址。
+
+---
+
+### 3. Quill / @vueup/vue-quill（2 条）
+
+| Issue | 状态 | 问题摘要 |
+| --- | --- | --- |
+| [#182](https://github.com/Tencent/wujie/issues/182) | Open | 输入多行后回车再插图片，前面文字丢失 |
+| [#479](https://github.com/Tencent/wujie/issues/479) | Closed | 工具栏点击控制台报错（与 wangEditor 同帖） |
+
+---
+
+### 4. CKEditor 5（1 条）
+
+| Issue | 状态 | 问题摘要 |
+| --- | --- | --- |
+| [#768](https://github.com/Tencent/wujie/issues/768) | Closed | 修改 URL query 重载后光标异常（Chrome/Edge）；指向 `getSelection()` |
+
+**关联修复：** [PR #792](https://github.com/Tencent/wujie/pull/792)（多子应用全局对象缓存）。
+
+---
+
+### 5. Tiptap（1 条）
+
+| Issue | 状态 | 问题摘要 |
+| --- | --- | --- |
+| [#858](https://github.com/Tencent/wujie/issues/858) | Open | 第二次打开子应用后，中文输入法 `@` 变 `@@`；`window.getSelection()` 恒为 `None` |
+
+---
+
+### 6. braft-editor（Draft.js 封装，2 条）
+
+| Issue | 状态 | 问题摘要 |
+| --- | --- | --- |
+| [#532](https://github.com/Tencent/wujie/issues/532) | Open | 光标总在首位，无法删改/换行；刷新后短暂正常 |
+| [#818](https://github.com/Tencent/wujie/issues/818) | Closed | iOS Safari：`InvalidStateError: extend() requires a Range...` |
+
+---
+
+### 7. Draft.js（1 条）
+
+| Issue | 状态 | 问题摘要 |
+| --- | --- | --- |
+| [#953](https://github.com/Tencent/wujie/issues/953) | Open | 光标一直在首位（与 braft 类问题类似） |
+
+---
+
+### 8. Slate（无独立标题 issue，在汇总中）
+
+| Issue | 状态 | 问题摘要 |
+| --- | --- | --- |
+| [#791](https://github.com/Tencent/wujie/issues/791) | Open | 通过 patch Slate + wujie + polyfill 插件临时可用 |
+| [#450](https://github.com/Tencent/wujie/issues/450) | Open | wangEditor 底层 Slate 报 `Cannot resolve a Slate range from DOM range` |
+
+---
+
+### 9. OnlyOffice（在线文档，1 条）
+
+| Issue | 状态 | 问题摘要 |
+| --- | --- | --- |
+| [#1083](https://github.com/Tencent/wujie/issues/1083) | Open | 主应用正常，子应用不展示或展示不全；怀疑沙箱阻隔内置 API |
+
+---
+
+### 10. 框架层（影响多数富文本，1 条）
+
+| Issue | 状态 | 问题摘要 |
+| --- | --- | --- |
+| [#770](https://github.com/Tencent/wujie/issues/770) | Open | 多子应用时 `getSelection()` 始终指向第一个 shadowRoot |
+
+与 [#768](https://github.com/Tencent/wujie/issues/768)、[#858](https://github.com/Tencent/wujie/issues/858) 等高度相关。
+
+---
+
+## 问题类型归纳
+
+### 高频根因
+
+| 根因 | 主要影响库 |
+| --- | --- |
+| `getSelection` / Selection 代理错误 | wangEditor、CKEditor5、Tiptap、braft / Draft.js |
+| `instanceof Node` / `HTMLElement` / `DataTransfer` 跨 realm | wangEditor、Slate |
+| `isCollapsed` 等 Selection API 失真 | wangEditor |
+| 资源加载：CSS / 皮肤文件 | TinyMCE |
+| 降级模式 `degrade` 行为差异 | wangEditor |
+| 事件 target 指向 `WUJIE-APP` | wangEditor |
+| 沙箱 / API 访问限制 | OnlyOffice |
+| 多子应用 Selection 指向错误 shadowRoot | 框架层（#770） |
+
+### 问题分布（按库）
+
+```
+wangEditor  ████████████████████  最多（~12+）
+TinyMCE     ███                   2（同一问题）
+Quill       ███                   2
+braft       ███                   2
+CKEditor5   ██                    1
+Tiptap      ██                    1
+Draft.js    ██                    1
+OnlyOffice  ██                    1
+框架层      ██                    1（#770，影响面广）
+```
+
+---
+
+## 社区常用缓解方向
+
+> 来自 issue 讨论，**非官方修复**；实施前需结合具体子应用栈验证。
+
+| 方向 | 说明 |
+| --- | --- |
+| [wujie-polyfill](https://github.com/Tencent/wujie-polyfill) | `selection`、`eventTarget` 等插件 |
+| 自定义 `plugins` | `jsBeforeLoaders` 重写 Selection / DataTransfer；`jsLoader` 替换 `instanceof`、`isCollapsed` |
+| wangEditor 官方 | 支持微前端 iframe 沙箱的 PR（[#791](https://github.com/Tencent/wujie/issues/791) 有链接） |
+| 多子应用 | 关注 [#792](https://github.com/Tencent/wujie/pull/792) 已合并的全局对象缓存修复 |
+| TinyMCE | init 时使用绝对 `skin_url` / `content_css`；确保 wujie 对延迟 href 的 `<link>` 能正确加载 |
+
+---
+
+## 与本仓库 demo / 修复的关联
+
+| 项 | 位置 / 说明 |
+| --- | --- |
+| 富文本示例路由 | `examples/vue2/src/views/RichText.vue` |
+| wangEditor demo | `examples/vue2/src/components/rich-text/WangEditorDemoBlock.vue` |
+| isCollapsed 验证 demo | `RichText.vue` — 「isCollapsed 判断正常」；`WangEditorDemoBlock` 的 `showSelectionPanel` |
+| TinyMCE demo | `examples/vue2/src/components/rich-text/TinyMceDemoBlock.vue` |
+| 延迟 href 的 `<link>` 处理 | `packages/wujie-core/src/effect.ts` — `deferStyleSheetByHref` |
+| `DataTransfer` instanceof 跨 realm | `packages/wujie-core/src/iframe.ts` — `patchInstanceofAcrossRealms`；降级模式见 `examples/main-vue/src/plugins/wangEditor.js` |
+| 降级 `getSelection` / `ownerDocument` | `packages/wujie-core/src/iframe.ts` — 指向 `sandbox.document`（渲染 iframe），修复 wangEditor LO/RO（#513） |
+| 降级 `patchDegradeInstanceofAcrossRealms` | `iframe.ts` + `sandbox.ts` — 渲染/执行 iframe 双向 instanceof；在 `document` 就绪后 patch，不改动 `createElement` |
+| 复制粘贴 demo | `RichText.vue` — 「复制粘贴（#479）」 |
+| 快速输入不失焦 demo | `RichText.vue` — 「快速输入不失焦（#513）」；含降级 LO/RO 面板 |
+| 关联 issue | [#218](https://github.com/Tencent/wujie/issues/218)、[#479](https://github.com/Tencent/wujie/issues/479)、[#489](https://github.com/Tencent/wujie/issues/489)、[#513](https://github.com/Tencent/wujie/issues/513)、[#450](https://github.com/Tencent/wujie/issues/450)、[#770](https://github.com/Tencent/wujie/issues/770)、[#224](https://github.com/Tencent/wujie/issues/224)、[#974](https://github.com/Tencent/wujie/issues/974) |

--- a/package.json
+++ b/package.json
@@ -4,6 +4,11 @@
   "description": "极致的微前端框架",
   "private": true,
   "packageManager": "pnpm@10.33.0",
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "puppeteer"
+    ]
+  },
   "scripts": {
     "start": "NODE_OPTIONS=--openssl-legacy-provider lerna run start --parallel",
     "doc": "lerna run docs:dev",

--- a/packages/wujie-core/__test__/integration/instanceof.test.ts
+++ b/packages/wujie-core/__test__/integration/instanceof.test.ts
@@ -1,0 +1,46 @@
+import { vueMainAppInfoMap } from "./common";
+import { awaitConsoleLogMessage } from "./utils";
+
+describe("main vue instanceof patch", () => {
+  beforeAll(async () => {
+    await page.evaluateOnNewDocument(() => {
+      localStorage.clear();
+      localStorage.setItem("preload", "false");
+      localStorage.setItem("degrade", "false");
+    });
+    await page.goto("http://localhost:8000/");
+  });
+
+  it("example 子应用中主应用 realm 的元素和事件应通过子应用构造函数的 instanceof 判断", async () => {
+    const appInfo = vueMainAppInfoMap.vue3;
+    const appInfoMountedPromise = awaitConsoleLogMessage(page, appInfo.mountedMessage);
+    await page.click(appInfo.linkSelector);
+    await appInfoMountedPromise;
+
+    const result = await page.evaluate((childName) => {
+      const childWindow = (window.frames as any)[childName];
+      const childProxyWindow = childWindow.__WUJIE.proxy;
+      const mainElement = document.createElement("div");
+      const mainMouseEvent = new MouseEvent("click");
+      const childElement = childWindow.document.createElement("div");
+
+      return {
+        mainElementIsChildDiv: mainElement instanceof childProxyWindow.HTMLDivElement,
+        mainElementIsChildHTMLElement: mainElement instanceof childProxyWindow.HTMLElement,
+        mainEventIsChildMouseEvent: mainMouseEvent instanceof childProxyWindow.MouseEvent,
+        mainEventIsChildEvent: mainMouseEvent instanceof childProxyWindow.Event,
+        childElementStillWorks: childElement instanceof childProxyWindow.HTMLDivElement,
+        hasPatchMark: childProxyWindow.HTMLDivElement._hasPatch === true,
+      };
+    }, appInfo.name);
+
+    expect(result).toEqual({
+      mainElementIsChildDiv: true,
+      mainElementIsChildHTMLElement: true,
+      mainEventIsChildMouseEvent: true,
+      mainEventIsChildEvent: true,
+      childElementStillWorks: true,
+      hasPatchMark: true,
+    });
+  });
+});

--- a/packages/wujie-core/__test__/unit/defer-style-href.test.ts
+++ b/packages/wujie-core/__test__/unit/defer-style-href.test.ts
@@ -1,0 +1,129 @@
+/**
+ * 关联 issue: https://github.com/Tencent/wujie/issues/224  https://github.com/Tencent/wujie/issues/974
+ *
+ * 场景：部分库（如 tinymce 的 StyleSheetLoader）动态插入 <link rel=stylesheet> 时，
+ * 先 appendChild(link)、之后才 setAttribute('href', url)。appendChild 时 href 为空，
+ * wujie 旧实现会直接用注释替换并丢弃该 link，导致样式（skin.min.css）永远加载不出来。
+ *
+ * deferStyleSheetByHref 通过 MutationObserver 监听 href 的后续赋值，命中后再走加载流程，
+ * 并在命中 / 超时 / destroy 时统一 disconnect，避免 observer 闭包钉住已销毁的 sandbox。
+ */
+
+export {};
+
+const { deferStyleSheetByHref } = require("../../src/effect");
+const { addSandboxCacheWithWujie, deleteWujieById } = require("../../src/common");
+
+const WUJIE_ID = "defer-style-href-app";
+
+function createSandbox(): any {
+  return { id: WUJIE_ID, deferredStyleObservers: [] };
+}
+
+function makeLink(): HTMLLinkElement {
+  const link = document.createElement("link");
+  link.setAttribute("rel", "stylesheet");
+  return link;
+}
+
+describe("deferStyleSheetByHref / 先 append 后 setAttribute('href') 的延迟加载", () => {
+  let sandbox: any;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    sandbox = createSandbox();
+    addSandboxCacheWithWujie(WUJIE_ID, sandbox);
+  });
+
+  afterEach(() => {
+    deleteWujieById(WUJIE_ID);
+    jest.useRealTimers();
+  });
+
+  it("后续 setAttribute('href') 应触发 loadStyleSheet 并带上真实 href", async () => {
+    const link = makeLink();
+    const loadStyleSheet = jest.fn();
+
+    deferStyleSheetByHref({ element: link, wujieId: WUJIE_ID, iframeWindow: window, loadStyleSheet });
+    expect(sandbox.deferredStyleObservers).toHaveLength(1);
+
+    link.setAttribute("href", "https://cdn.example.com/skin.min.css");
+    // MutationObserver 回调在 microtask 中触发
+    await Promise.resolve();
+
+    expect(loadStyleSheet).toHaveBeenCalledTimes(1);
+    expect(loadStyleSheet).toHaveBeenCalledWith("https://cdn.example.com/skin.min.css", link);
+  });
+
+  it("后续设置相对 href 时应传入浏览器解析后的绝对 href", async () => {
+    const link = makeLink();
+    const loadStyleSheet = jest.fn();
+
+    deferStyleSheetByHref({ element: link, wujieId: WUJIE_ID, iframeWindow: window, loadStyleSheet });
+
+    link.setAttribute("href", "./tinymce/skins/ui/oxide/skin.min.css");
+    await Promise.resolve();
+
+    expect(loadStyleSheet).toHaveBeenCalledTimes(1);
+    expect(loadStyleSheet).toHaveBeenCalledWith(link.href, link);
+    expect(loadStyleSheet.mock.calls[0][0]).not.toBe("./tinymce/skins/ui/oxide/skin.min.css");
+  });
+
+  it("命中后应 disconnect 并从 sandbox.deferredStyleObservers 出队", async () => {
+    const link = makeLink();
+    const loadStyleSheet = jest.fn();
+
+    deferStyleSheetByHref({ element: link, wujieId: WUJIE_ID, iframeWindow: window, loadStyleSheet });
+    link.setAttribute("href", "https://cdn.example.com/skin.min.css");
+    await Promise.resolve();
+
+    expect(sandbox.deferredStyleObservers).toHaveLength(0);
+
+    // 再次改 href 不应重复加载（已 disconnect）
+    link.setAttribute("href", "https://cdn.example.com/other.css");
+    await Promise.resolve();
+    expect(loadStyleSheet).toHaveBeenCalledTimes(1);
+  });
+
+  it("超时未拿到 href 时应放弃监听、出队并触发 error 事件", () => {
+    const link = makeLink();
+    const loadStyleSheet = jest.fn();
+    const onerror = jest.fn();
+    link.onerror = onerror;
+
+    deferStyleSheetByHref({ element: link, wujieId: WUJIE_ID, iframeWindow: window, loadStyleSheet });
+    expect(sandbox.deferredStyleObservers).toHaveLength(1);
+
+    jest.advanceTimersByTime(5000);
+
+    expect(loadStyleSheet).not.toHaveBeenCalled();
+    expect(onerror).toHaveBeenCalledTimes(1);
+    expect(sandbox.deferredStyleObservers).toHaveLength(0);
+  });
+
+  it("子应用已销毁后再赋值 href 不应执行 loadStyleSheet", async () => {
+    const link = makeLink();
+    const loadStyleSheet = jest.fn();
+
+    deferStyleSheetByHref({ element: link, wujieId: WUJIE_ID, iframeWindow: window, loadStyleSheet });
+    // 模拟 destroy：统一 disconnect 并移除全局缓存
+    sandbox.deferredStyleObservers.forEach((o: MutationObserver) => o.disconnect());
+    deleteWujieById(WUJIE_ID);
+
+    link.setAttribute("href", "https://cdn.example.com/skin.min.css");
+    await Promise.resolve();
+
+    expect(loadStyleSheet).not.toHaveBeenCalled();
+  });
+
+  it("环境不支持 MutationObserver 时应安全跳过，不抛错也不入队", () => {
+    const link = makeLink();
+    const loadStyleSheet = jest.fn();
+    const fakeWindow = {} as unknown as Window;
+
+    expect(() =>
+      deferStyleSheetByHref({ element: link, wujieId: WUJIE_ID, iframeWindow: fakeWindow, loadStyleSheet })
+    ).not.toThrow();
+    expect(sandbox.deferredStyleObservers).toHaveLength(0);
+  });
+});

--- a/packages/wujie-core/__test__/unit/defer-style-observer-cleanup.test.ts
+++ b/packages/wujie-core/__test__/unit/defer-style-observer-cleanup.test.ts
@@ -1,0 +1,63 @@
+/**
+ * sandbox.clearDeferredStyleObservers() 在 destroy 路径上的清理行为。
+ *
+ * 动态 <link> 以空 href 插入时（如 tinymce），effect.ts 会注册 MutationObserver 监听
+ * href 赋值并登记到 sandbox.deferredStyleObservers。若子应用在 href 赋值前被销毁，
+ * destroy 必须统一 disconnect 这些 observer，否则游离 link → registered observer →
+ * 回调闭包链路会把已销毁的 sandbox 钉在内存中。
+ */
+
+export {};
+
+const Sandbox = require("../../src/sandbox").default;
+
+function createMinimalSandbox(): any {
+  const sandbox = Object.create(Sandbox.prototype);
+  sandbox.deferredStyleObservers = [];
+  return sandbox;
+}
+
+describe("deferredStyleObservers destroy 时的清理", () => {
+  test("Wujie.prototype.clearDeferredStyleObservers 应作为公开方法存在", () => {
+    expect(typeof Sandbox.prototype.clearDeferredStyleObservers).toBe("function");
+  });
+
+  test("clearDeferredStyleObservers 应 disconnect 全部 observer 并清空数组", () => {
+    const sandbox = createMinimalSandbox();
+    const o1 = { disconnect: jest.fn() };
+    const o2 = { disconnect: jest.fn() };
+    sandbox.deferredStyleObservers.push(o1, o2);
+
+    sandbox.clearDeferredStyleObservers();
+
+    expect(o1.disconnect).toHaveBeenCalledTimes(1);
+    expect(o2.disconnect).toHaveBeenCalledTimes(1);
+    expect(sandbox.deferredStyleObservers).toEqual([]);
+  });
+
+  test("某个 observer.disconnect 抛错不应中断后续清理", () => {
+    const sandbox = createMinimalSandbox();
+    const bad = {
+      disconnect: jest.fn(() => {
+        throw new Error("boom");
+      }),
+    };
+    const good = { disconnect: jest.fn() };
+    sandbox.deferredStyleObservers.push(bad, good);
+
+    expect(() => sandbox.clearDeferredStyleObservers()).not.toThrow();
+    expect(good.disconnect).toHaveBeenCalledTimes(1);
+    expect(sandbox.deferredStyleObservers).toEqual([]);
+  });
+
+  test("clearDeferredStyleObservers 应保留数组引用（仅清空内容）", () => {
+    const sandbox = createMinimalSandbox();
+    const arrayRef = sandbox.deferredStyleObservers;
+    arrayRef.push({ disconnect: jest.fn() });
+
+    sandbox.clearDeferredStyleObservers();
+
+    expect(sandbox.deferredStyleObservers).toBe(arrayRef);
+    expect(arrayRef.length).toBe(0);
+  });
+});

--- a/packages/wujie-core/__test__/unit/event.test.ts
+++ b/packages/wujie-core/__test__/unit/event.test.ts
@@ -1,8 +1,3 @@
-interface Window {
-  __POWERED_BY_WUJIE__?: boolean;
-  __WUJIE: { inject: { appEventObjMap: Map<String, { [event: string]: Array<Function> }> } };
-}
-
 const warn = jest.fn();
 
 jest.mock("../../src/utils", () => {

--- a/packages/wujie-core/__test__/unit/instanceof-patch.test.ts
+++ b/packages/wujie-core/__test__/unit/instanceof-patch.test.ts
@@ -31,6 +31,11 @@ describe("patchInstanceofAcrossRealms", () => {
     expect(mainElement instanceof iframeWindow.HTMLElement).toBe(true);
     expect(mainMouseEvent instanceof iframeWindow.MouseEvent).toBe(true);
     expect(mainMouseEvent instanceof iframeWindow.Event).toBe(true);
+
+    if (typeof window.DataTransfer === "function") {
+      const mainDataTransfer = new window.DataTransfer();
+      expect(mainDataTransfer instanceof iframeWindow.DataTransfer).toBe(true);
+    }
   });
 
   test("保留子应用 realm 原有 instanceof 判断", () => {
@@ -56,5 +61,25 @@ describe("patchInstanceofAcrossRealms", () => {
 
     expect((iframeWindow.HTMLDivElement as any)._hasPatch).toBe(true);
     expect(iframeWindow.HTMLDivElement[Symbol.hasInstance]).toBe(patchedHasInstance);
+  });
+
+  test("降级模式：渲染 iframe 与执行 iframe 双向 instanceof", () => {
+    const appWindow = createIframeWindow();
+    const renderFrame = document.createElement("iframe");
+    document.body.appendChild(renderFrame);
+    const renderWindow = renderFrame.contentWindow as any;
+
+    const patchDegradeInstanceofAcrossRealms = (iframeModule as any).patchDegradeInstanceofAcrossRealms;
+
+    const appElement = appWindow.document.createElement("div");
+    const renderElement = renderWindow.document.createElement("div");
+
+    expect(appElement instanceof renderWindow.HTMLDivElement).toBe(false);
+    expect(renderElement instanceof appWindow.HTMLDivElement).toBe(false);
+
+    patchDegradeInstanceofAcrossRealms(appWindow, renderWindow);
+
+    expect(appElement instanceof renderWindow.HTMLDivElement).toBe(true);
+    expect(renderElement instanceof appWindow.HTMLDivElement).toBe(true);
   });
 });

--- a/packages/wujie-core/__test__/unit/instanceof-patch.test.ts
+++ b/packages/wujie-core/__test__/unit/instanceof-patch.test.ts
@@ -1,0 +1,60 @@
+export {};
+
+import * as iframeModule from "../../src/iframe";
+
+function createIframeWindow() {
+  const iframe = document.createElement("iframe");
+  document.body.appendChild(iframe);
+  return iframe.contentWindow as any;
+}
+
+describe("patchInstanceofAcrossRealms", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  test("让主应用 realm 的元素和事件通过子应用构造函数的 instanceof 判断", () => {
+    const iframeWindow = createIframeWindow();
+    const patchInstanceofAcrossRealms = (iframeModule as any).patchInstanceofAcrossRealms;
+
+    expect(typeof patchInstanceofAcrossRealms).toBe("function");
+
+    const mainElement = document.createElement("div");
+    const mainMouseEvent = new MouseEvent("click");
+
+    expect(mainElement instanceof iframeWindow.HTMLDivElement).toBe(false);
+    expect(mainMouseEvent instanceof iframeWindow.MouseEvent).toBe(false);
+
+    patchInstanceofAcrossRealms(iframeWindow);
+
+    expect(mainElement instanceof iframeWindow.HTMLDivElement).toBe(true);
+    expect(mainElement instanceof iframeWindow.HTMLElement).toBe(true);
+    expect(mainMouseEvent instanceof iframeWindow.MouseEvent).toBe(true);
+    expect(mainMouseEvent instanceof iframeWindow.Event).toBe(true);
+  });
+
+  test("保留子应用 realm 原有 instanceof 判断", () => {
+    const iframeWindow = createIframeWindow();
+    const patchInstanceofAcrossRealms = (iframeModule as any).patchInstanceofAcrossRealms;
+    const childElement = iframeWindow.document.createElement("div");
+    const childMouseEvent = new iframeWindow.MouseEvent("click");
+
+    patchInstanceofAcrossRealms(iframeWindow);
+
+    expect(childElement instanceof iframeWindow.HTMLDivElement).toBe(true);
+    expect(childMouseEvent instanceof iframeWindow.MouseEvent).toBe(true);
+  });
+
+  test("重复 patch 时应保持幂等，避免 hasInstance 闭包堆叠", () => {
+    const iframeWindow = createIframeWindow();
+    const patchInstanceofAcrossRealms = (iframeModule as any).patchInstanceofAcrossRealms;
+
+    patchInstanceofAcrossRealms(iframeWindow);
+    const patchedHasInstance = iframeWindow.HTMLDivElement[Symbol.hasInstance];
+
+    patchInstanceofAcrossRealms(iframeWindow);
+
+    expect((iframeWindow.HTMLDivElement as any)._hasPatch).toBe(true);
+    expect(iframeWindow.HTMLDivElement[Symbol.hasInstance]).toBe(patchedHasInstance);
+  });
+});

--- a/packages/wujie-core/jest-puppeteer.config.js
+++ b/packages/wujie-core/jest-puppeteer.config.js
@@ -5,10 +5,12 @@ const LERNA_EXEC = resolve(__dirname, "../../node_modules/.bin/lerna");
 // 本地开发不设置该变量时保持默认行为
 const launchArgs = (process.env.PUPPETEER_LAUNCH_ARGS || "").split(/\s+/).filter(Boolean);
 
+const isDebug = false;
+
 module.exports = {
   launch: {
-    headless: true,
-    devtools: false,
+    headless: !isDebug,
+    devtools: isDebug,
     product: "chrome",
     ...(launchArgs.length ? { args: launchArgs } : {}),
   },

--- a/packages/wujie-core/package.json
+++ b/packages/wujie-core/package.json
@@ -18,7 +18,8 @@
     "test": "npm run test:unit && NODE_OPTIONS=--openssl-legacy-provider npm run test:integration",
     "test:unit": "jest -c __test__/unit/jest.config.js",
     "kill-integration-ports": "node scripts/kill-integration-ports.js",
-    "test:integration": "npm run kill-integration-ports && NODE_OPTIONS=--openssl-legacy-provider jest -c __test__/integration/jest.config.js --runInBand"
+    "install-puppeteer-browser": "node ./node_modules/puppeteer/install.js",
+    "test:integration": "npm run install-puppeteer-browser && npm run kill-integration-ports && NODE_OPTIONS=--openssl-legacy-provider jest -c __test__/integration/jest.config.js --runInBand"
   },
   "repository": {
     "type": "git",

--- a/packages/wujie-core/package.json
+++ b/packages/wujie-core/package.json
@@ -17,7 +17,8 @@
     "lint": "eslint --ext .ts ./src  --fix",
     "test": "npm run test:unit && NODE_OPTIONS=--openssl-legacy-provider npm run test:integration",
     "test:unit": "jest -c __test__/unit/jest.config.js",
-    "test:integration": "jest -c __test__/integration/jest.config.js --runInBand"
+    "kill-integration-ports": "node scripts/kill-integration-ports.js",
+    "test:integration": "npm run kill-integration-ports && NODE_OPTIONS=--openssl-legacy-provider jest -c __test__/integration/jest.config.js --runInBand"
   },
   "repository": {
     "type": "git",

--- a/packages/wujie-core/scripts/kill-integration-ports.js
+++ b/packages/wujie-core/scripts/kill-integration-ports.js
@@ -1,0 +1,87 @@
+/**
+ * 集成测试启动前释放 jest-puppeteer.config.js 里占用的端口。
+ * jest-dev-server 的 usedPortAction: "kill" 依赖 find-process，在 macOS 上常查不到监听进程会报错。
+ */
+const { execSync } = require("child_process");
+
+/** 与 jest-puppeteer.config.js 中 server[].port 保持一致 */
+const INTEGRATION_PORTS = [7600, 7100, 7200, 7300, 7500, 7400, 7700, 8000];
+
+function execQuiet(command) {
+  return execSync(command, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  }).trim();
+}
+
+/** @returns {string[]} */
+function getListenerPidsOnPort(port) {
+  const platform = process.platform;
+
+  if (platform === "win32") {
+    try {
+      const stdout = execQuiet(`netstat -ano | findstr :${port}`);
+      const pids = stdout
+        .split("\n")
+        .map((line) => line.trim().split(/\s+/))
+        .filter((parts) => parts.length >= 5 && parts[3] === "LISTENING")
+        .map((parts) => parts[parts.length - 1]);
+      return [...new Set(pids.filter(Boolean))];
+    } catch {
+      return [];
+    }
+  }
+
+  // macOS / Linux / 其他类 Unix：优先 lsof
+  try {
+    const stdout = execQuiet(`lsof -nP -iTCP:${port} -sTCP:LISTEN -t`);
+    return [...new Set(stdout.split("\n").filter(Boolean))];
+  } catch {
+    /* lsof 未安装或 -s 语法不支持时走 Linux 常见兜底 */
+  }
+
+  if (platform === "linux") {
+    try {
+      // fuser 在多数 Linux 发行版默认可用
+      const stdout = execQuiet(`fuser -n tcp ${port} 2>/dev/null`);
+      return [...new Set(stdout.split(/\s+/).filter(Boolean))];
+    } catch {
+      /* ignore */
+    }
+
+    try {
+      // ss 常见于 util-linux，输出形如 users:(("node",pid=12345,fd=20))
+      const stdout = execQuiet(`ss -H -ltnp sport = :${port}`);
+      const pids = [...stdout.matchAll(/pid=(\d+)/g)].map((m) => m[1]);
+      return [...new Set(pids)];
+    } catch {
+      return [];
+    }
+  }
+
+  return [];
+}
+
+function killListenersOnPort(port) {
+  const pids = getListenerPidsOnPort(port);
+  pids.forEach((pid) => {
+    try {
+      process.kill(Number(pid), "SIGTERM");
+      console.log(`[kill-integration-ports] SIGTERM pid=${pid} port=${port}`);
+    } catch (error) {
+      if (error.code !== "ESRCH") {
+        console.warn(`[kill-integration-ports] failed pid=${pid} port=${port}:`, error.message);
+      }
+    }
+  });
+}
+
+function delay(ms) {
+  const end = Date.now() + ms;
+  while (Date.now() < end) {
+    /* 跨平台等待端口释放，避免依赖 shell 的 sleep */
+  }
+}
+
+INTEGRATION_PORTS.forEach(killListenersOnPort);
+delay(500);

--- a/packages/wujie-core/src/effect.ts
+++ b/packages/wujie-core/src/effect.ts
@@ -17,6 +17,7 @@ import {
   warn,
   nextTick,
   getCurUrl,
+  getAbsolutePath,
   execHooks,
   isScriptElement,
   setTagToScript,
@@ -182,6 +183,79 @@ export function patchStylesheetElement(
   });
 }
 
+// href 延迟赋值的兜底超时（毫秒）：超过该时间仍未拿到 href，则放弃监听并触发 error，
+// 防止「href 永不到达」时 observer 闭包长期钉住子应用上下文。沿用 tinymce maxLoadTime 量级。
+const DEFER_STYLE_HREF_TIMEOUT = 5000;
+
+/**
+ * 处理「先 appendChild(link) 后 setAttribute('href')」的延迟 href 场景。
+ *
+ * 通过 MutationObserver 监听 href 属性赋值，命中后走传入的 loadStyleSheet 完成加载。
+ * 生命周期管理（避免内存泄漏）：
+ *   1. 命中 / 超时 / 子应用已销毁 时立即 disconnect 并从 sandbox 出队；
+ *   2. observer 登记到 sandbox.deferredStyleObservers，destroy 阶段统一兜底 disconnect；
+ *   3. 回调内通过 wujieId 动态获取 sandbox，不捕获 sandbox/iframe，子应用销毁后闭包不再 pin 上下文。
+ */
+export function deferStyleSheetByHref(opts: {
+  element: HTMLLinkElement;
+  wujieId: string;
+  iframeWindow: Window;
+  loadStyleSheet: (href: string, element: HTMLLinkElement) => void;
+}): void {
+  let { element } = opts;
+  const { wujieId, iframeWindow, loadStyleSheet } = opts;
+  // 部分环境（jsdom / 老浏览器）可能不支持 MutationObserver，直接放弃延迟处理
+  const MutationObserverCtor = (iframeWindow as any).MutationObserver;
+  if (typeof MutationObserverCtor !== "function") return;
+
+  let settled = false;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  const observer: MutationObserver = new MutationObserverCtor(() => {
+    if (settled) return;
+    const attrHref = element?.getAttribute("href");
+    if (!attrHref) return;
+    const realHref = element.href || attrHref;
+    const target = element;
+    finalize(() => target && loadStyleSheet(realHref, target));
+  });
+
+  // 统一收尾：disconnect + 出队 + 清理定时器，再执行收尾动作
+  function finalize(action?: () => void) {
+    if (settled) return;
+    settled = true;
+    if (timer !== null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    try {
+      observer.disconnect();
+    } catch (_) {
+      /* noop */
+    }
+    // 动态获取 sandbox，子应用销毁后直接放手，闭包不再钉住上下文
+    const sandbox = getWujieById(wujieId);
+    const observers = sandbox?.deferredStyleObservers;
+    if (Array.isArray(observers)) {
+      const index = observers.indexOf(observer);
+      if (index !== -1) observers.splice(index, 1);
+    }
+    if (sandbox) action?.();
+    element = null;
+  }
+
+  const sandbox = getWujieById(wujieId);
+  // 子应用已不存在则无需监听
+  if (!sandbox || !Array.isArray(sandbox.deferredStyleObservers)) return;
+  sandbox.deferredStyleObservers.push(observer);
+  observer.observe(element, { attributes: true, attributeFilter: ["href"] });
+  // 超时兜底：长时间没等到 href，放弃监听并触发 error，让上游（如 tinymce）的失败回调收尾
+  timer = setTimeout(() => {
+    const target = element;
+    finalize();
+    if (target) manualInvokeElementEvent(target, "error");
+  }, DEFER_STYLE_HREF_TIMEOUT);
+}
+
 let dynamicScriptExecStack = Promise.resolve();
 function rewriteAppendOrInsertChild(opts: {
   rawDOMAppendOrInsertBefore: <T extends Node>(newChild: T, refChild?: Node | null) => T;
@@ -220,30 +294,26 @@ function rewriteAppendOrInsertChild(opts: {
             execHooks(plugins, "appendOrInsertElementHook", element, iframe.contentWindow);
             return res;
           }
-          // 排除css
-          if (href && !isMatchUrl(href, getEffectLoaders("cssExcludes", plugins))) {
+
+          // 拉取 css 内容并以 <style> 注入子应用、回调 link 的 load/error 事件。
+          // 抽成闭包以便「append 时已有 href」与「append 后才 setAttribute('href')」两条路径复用。
+          const loadStyleSheet = (realHref: string, linkElement: HTMLLinkElement) => {
+            const attrHref = linkElement.getAttribute("href");
+            const styleHref = attrHref ? getAbsolutePath(attrHref, (proxyLocation as Location).href) : realHref;
+            const exclude = isMatchUrl(styleHref, getEffectLoaders("cssExcludes", plugins));
+            if (!styleHref || exclude) return;
             getExternalStyleSheets(
-              [{ src: href, ignore: isMatchUrl(href, getEffectLoaders("cssIgnores", plugins)) }],
+              [{ src: styleHref, ignore: isMatchUrl(styleHref, getEffectLoaders("cssIgnores", plugins)) }],
               fetch,
               lifecycles.loadError
             ).forEach(({ src, ignore, contentPromise }) =>
               contentPromise.then(
                 (content) => {
                   // 处理 ignore 样式
-                  const rawAttrs = parseTagAttributes(element.outerHTML);
+                  const rawAttrs = parseTagAttributes(linkElement.outerHTML);
                   if (ignore && src) {
-                    // const stylesheetElement = iframeDocument.createElement("link");
-                    // const attrs = {
-                    //   ...rawAttrs,
-                    //   type: "text/css",
-                    //   rel: "stylesheet",
-                    //   href: src,
-                    // };
-                    // setAttrsToElement(stylesheetElement, attrs);
-                    // rawDOMAppendOrInsertBefore.call(this, stylesheetElement, refChild);
-                    // manualInvokeElementEvent(element, "load");
                     // 忽略的元素应该直接把对应元素插入，而不是用新的 link 标签进行替代插入，保证 element 的上下文正常
-                    rawDOMAppendOrInsertBefore.call(this, element, refChild);
+                    rawDOMAppendOrInsertBefore.call(this, linkElement, refChild);
                   } else {
                     // 记录js插入样式，子应用重新激活时恢复
                     const stylesheetElement = iframeDocument.createElement("style");
@@ -255,16 +325,31 @@ function rewriteAppendOrInsertChild(opts: {
                     rawDOMAppendOrInsertBefore.call(this, stylesheetElement, refChild);
                     // 处理样式补丁
                     handleStylesheetElementPatch(stylesheetElement, sandbox);
-                    manualInvokeElementEvent(element, "load");
+                    manualInvokeElementEvent(linkElement, "load");
                   }
-                  element = null;
+                  if (element === linkElement) element = null;
                 },
                 () => {
-                  manualInvokeElementEvent(element, "error");
-                  element = null;
+                  manualInvokeElementEvent(linkElement, "error");
+                  if (element === linkElement) element = null;
                 }
               )
             );
+          };
+
+          if (href) {
+            // 排除css
+            if (!isMatchUrl(href, getEffectLoaders("cssExcludes", plugins))) {
+              loadStyleSheet(href, element);
+            }
+          } else {
+            // 关联 issue: https://github.com/Tencent/wujie/issues/224 https://github.com/Tencent/wujie/issues/974
+            //
+            // 部分库（如 tinymce 的 StyleSheetLoader）先 appendChild(link) 再
+            // setAttribute('href', url)。此时 href 为空，若直接丢弃则该样式永远不会被加载，
+            // 后续在游离 link 上设置 href 也不会触发浏览器加载，skin.min.css 等资源缺失。
+            // 这里监听 href 的后续赋值，拿到真实 href 后再走与上面完全一致的加载流程。
+            deferStyleSheetByHref({ element, wujieId, iframeWindow: iframe.contentWindow, loadStyleSheet });
           }
 
           const comment = iframeDocument.createComment(`dynamic link ${href} replaced by wujie`);

--- a/packages/wujie-core/src/iframe.ts
+++ b/packages/wujie-core/src/iframe.ts
@@ -38,6 +38,33 @@ import { getJsLoader } from "./plugin";
 import { WUJIE_TIPS_SCRIPT_ERROR_REQUESTED, WUJIE_DATA_FLAG } from "./constant";
 import { ScriptObjectLoader } from "./index";
 
+const extraInstanceofConstructorNames = new Set([
+  "CSSStyleDeclaration",
+  "DOMImplementation",
+  "DOMMatrix",
+  "DOMMatrixReadOnly",
+  "DOMParser",
+  "DOMPoint",
+  "DOMPointReadOnly",
+  "DOMQuad",
+  "DOMRect",
+  "DOMRectList",
+  "DOMRectReadOnly",
+  "DOMStringList",
+  "DOMStringMap",
+  "DOMTokenList",
+  "HTMLCollection",
+  "MediaList",
+  "NamedNodeMap",
+  "Range",
+  "Selection",
+  "StyleSheet",
+  "StyleSheetList",
+  "TextDecoder",
+  "TextEncoder",
+  "TimeRanges",
+]);
+
 declare global {
   interface Window {
     // 是否存在无界
@@ -290,8 +317,60 @@ export function patchWindowEffect(iframeWindow: Window): void {
       warn(e.message);
     }
   });
+  if (!iframeWindow.__WUJIE.degrade) patchInstanceofAcrossRealms(iframeWindow);
   // 运行插件钩子函数
   execHooks(iframeWindow.__WUJIE.plugins, "windowPropertyOverride", iframeWindow);
+}
+
+function isDomConstructor(name: string, ctor: Function, mainWindow: Window): boolean {
+  const prototype = ctor.prototype;
+  if (!prototype) return false;
+  if (ctor === mainWindow.EventTarget || ctor === mainWindow.Event) return true;
+  if (prototype instanceof mainWindow.EventTarget || prototype instanceof mainWindow.Event) return true;
+  if (/^(HTML|SVG|MathML).+Element$/.test(name)) return true;
+  return extraInstanceofConstructorNames.has(name);
+}
+
+/**
+ * 修复非降级模式下，主应用 realm 的 DOM 对象无法通过子应用 realm 构造函数 instanceof 的问题。
+ */
+export function patchInstanceofAcrossRealms(iframeWindow: Window): void {
+  // DOM 构造函数之间存在继承链（HTMLIFrameElement -> HTMLElement -> Element -> Node ...），
+  // 对构造函数的属性读取会沿这条链向上查找。因此 _hasPatch / Symbol.hasInstance 必须用 own
+  // 语义判断，否则会读到已被 patch 的祖先构造函数的值，导致 patch 被跳过或判断串味到祖先 realm。
+  const nativeHasInstance = Function.prototype[Symbol.hasInstance];
+  Object.getOwnPropertyNames(iframeWindow).forEach((name) => {
+    let appConstructor: Function & { _hasPatch?: boolean };
+    let mainConstructor: Function;
+
+    try {
+      appConstructor = iframeWindow[name];
+      mainConstructor = window[name];
+    } catch (error) {
+      return;
+    }
+
+    if (typeof appConstructor !== "function" || typeof mainConstructor !== "function") return;
+    if (appConstructor === mainConstructor || Object.prototype.hasOwnProperty.call(appConstructor, "_hasPatch")) return;
+    if (!isDomConstructor(name, mainConstructor, window)) return;
+
+    try {
+      Object.defineProperties(appConstructor, {
+        [Symbol.hasInstance]: {
+          configurable: true,
+          value(element: unknown) {
+            // 用 this 而非闭包变量，确保命中的始终是当前构造函数自己的判断，
+            // 用原生 hasInstance 避免沿构造函数继承链拿到被 patch 的祖先实现。
+            if (nativeHasInstance.call(this, element)) return true;
+            return element instanceof mainConstructor;
+          },
+        },
+        _hasPatch: { value: true },
+      });
+    } catch (error) {
+      console.warn(error);
+    }
+  });
 }
 
 /**

--- a/packages/wujie-core/src/iframe.ts
+++ b/packages/wujie-core/src/iframe.ts
@@ -39,7 +39,9 @@ import { WUJIE_TIPS_SCRIPT_ERROR_REQUESTED, WUJIE_DATA_FLAG } from "./constant";
 import { ScriptObjectLoader } from "./index";
 
 const extraInstanceofConstructorNames = new Set([
+  "ClipboardEvent",
   "CSSStyleDeclaration",
+  "DataTransfer",
   "DOMImplementation",
   "DOMMatrix",
   "DOMMatrixReadOnly",
@@ -268,7 +270,14 @@ export function patchWindowEffect(iframeWindow: Window): void {
     // 特殊处理
     if (key === "getSelection") {
       Object.defineProperty(iframeWindow, key, {
-        get: () => iframeWindow.document[key],
+        get: () => {
+          const sandbox = iframeWindow.__WUJIE;
+          // 降级模式：可见 DOM 在渲染 iframe，getSelection 需读 sandbox.document
+          if (sandbox?.degrade && sandbox.document) {
+            return sandbox.document.getSelection.bind(sandbox.document);
+          }
+          return iframeWindow.document[key];
+        },
       });
       return;
     }
@@ -317,52 +326,58 @@ export function patchWindowEffect(iframeWindow: Window): void {
       warn(e.message);
     }
   });
-  if (!iframeWindow.__WUJIE.degrade) patchInstanceofAcrossRealms(iframeWindow);
-  // 运行插件钩子函数
-  execHooks(iframeWindow.__WUJIE.plugins, "windowPropertyOverride", iframeWindow);
+  // 降级模式 DOM 在渲染 iframe，instanceof 需在 document 就绪后由 patchDegradeInstanceofAcrossRealms 处理
+  if (!iframeWindow.__WUJIE.degrade) {
+    patchInstanceofAcrossRealms(iframeWindow);
+  } else {
+    execHooks(iframeWindow.__WUJIE.plugins, "windowPropertyOverride", iframeWindow);
+  }
 }
 
-function isDomConstructor(name: string, ctor: Function, mainWindow: Window): boolean {
+function isDomConstructor(name: string, ctor: Function, peerWindow: Window): boolean {
   const prototype = ctor.prototype;
   if (!prototype) return false;
-  if (ctor === mainWindow.EventTarget || ctor === mainWindow.Event) return true;
-  if (prototype instanceof mainWindow.EventTarget || prototype instanceof mainWindow.Event) return true;
+  if (ctor === peerWindow.EventTarget || ctor === peerWindow.Event) return true;
+  if (prototype instanceof peerWindow.EventTarget || prototype instanceof peerWindow.Event) return true;
   if (/^(HTML|SVG|MathML).+Element$/.test(name)) return true;
   return extraInstanceofConstructorNames.has(name);
 }
 
 /**
- * 修复非降级模式下，主应用 realm 的 DOM 对象无法通过子应用 realm 构造函数 instanceof 的问题。
+ * 让 targetWindow 上的 DOM 构造函数 instanceof 同时认可 peerWindow realm 的对象。
+ * 非降级：targetWindow=子应用 JS iframe，peerWindow=主应用 window（DOM 在 shadowRoot）。
+ * 降级：在 patchDegradeInstanceofAcrossRealms 中对渲染 iframe 与执行 iframe 双向调用。
  */
-export function patchInstanceofAcrossRealms(iframeWindow: Window): void {
+export function patchInstanceofAcrossRealms(targetWindow: Window, peerWindow: Window = window): void {
   // DOM 构造函数之间存在继承链（HTMLIFrameElement -> HTMLElement -> Element -> Node ...），
   // 对构造函数的属性读取会沿这条链向上查找。因此 _hasPatch / Symbol.hasInstance 必须用 own
   // 语义判断，否则会读到已被 patch 的祖先构造函数的值，导致 patch 被跳过或判断串味到祖先 realm。
   const nativeHasInstance = Function.prototype[Symbol.hasInstance];
-  Object.getOwnPropertyNames(iframeWindow).forEach((name) => {
-    let appConstructor: Function & { _hasPatch?: boolean };
-    let mainConstructor: Function;
+  Object.getOwnPropertyNames(targetWindow).forEach((name) => {
+    let targetConstructor: Function & { _hasPatch?: boolean };
+    let peerConstructor: Function;
 
     try {
-      appConstructor = iframeWindow[name];
-      mainConstructor = window[name];
+      targetConstructor = targetWindow[name];
+      peerConstructor = peerWindow[name];
     } catch (error) {
       return;
     }
 
-    if (typeof appConstructor !== "function" || typeof mainConstructor !== "function") return;
-    if (appConstructor === mainConstructor || Object.prototype.hasOwnProperty.call(appConstructor, "_hasPatch")) return;
-    if (!isDomConstructor(name, mainConstructor, window)) return;
+    if (typeof targetConstructor !== "function" || typeof peerConstructor !== "function") return;
+    if (targetConstructor === peerConstructor || Object.prototype.hasOwnProperty.call(targetConstructor, "_hasPatch"))
+      return;
+    if (!isDomConstructor(name, peerConstructor, peerWindow)) return;
 
     try {
-      Object.defineProperties(appConstructor, {
+      Object.defineProperties(targetConstructor, {
         [Symbol.hasInstance]: {
           configurable: true,
           value(element: unknown) {
-            // 用 this 而非闭包变量，确保命中的始终是当前构造函数自己的判断，
-            // 用原生 hasInstance 避免沿构造函数继承链拿到被 patch 的祖先实现。
+            // 用 this 而非闭包变量，确保命中的始终是当前构造函数自己的判断。
+            // 对端也用原生 hasInstance，避免双向 patch 时 element instanceof peerConstructor 递归栈溢出。
             if (nativeHasInstance.call(this, element)) return true;
-            return element instanceof mainConstructor;
+            return nativeHasInstance.call(peerConstructor, element);
           },
         },
         _hasPatch: { value: true },
@@ -371,6 +386,20 @@ export function patchInstanceofAcrossRealms(iframeWindow: Window): void {
       console.warn(error);
     }
   });
+  const wujie = (targetWindow as Window & { __WUJIE?: WuJie }).__WUJIE;
+  if (wujie) {
+    execHooks(wujie.plugins, "windowPropertyOverride", targetWindow);
+  }
+}
+
+/**
+ * 降级模式：DOM 在渲染 iframe、JS 在执行 iframe，对两侧 window 双向 patch instanceof。
+ * 需在 sandbox.document（渲染 document）就绪后调用，勿在 patchWindowEffect 阶段调用。
+ */
+export function patchDegradeInstanceofAcrossRealms(appWindow: Window, renderWindow: Window): void {
+  if (!renderWindow || appWindow === renderWindow) return;
+  patchInstanceofAcrossRealms(renderWindow, appWindow);
+  patchInstanceofAcrossRealms(appWindow, renderWindow);
 }
 
 /**
@@ -883,6 +912,11 @@ export function patchElementEffect(
           // win.__WUJIE 被置 null（destroy 后）或 win 本身已 GC 时降级到主 document，
           // 防止 element 永久把 iframeWindow 钉在内存中。
           if (!win || !win.__WUJIE) return window.document;
+          // 降级模式：节点已挂到渲染 iframe，ownerDocument 需与可见 DOM 一致，
+          // 否则 wangEditor LO/RO（node.ownerDocument.defaultView instanceof）会失败。
+          if (win.__WUJIE.degrade && win.__WUJIE.document) {
+            return win.__WUJIE.document;
+          }
           return win.document;
         },
       },

--- a/packages/wujie-core/src/sandbox.ts
+++ b/packages/wujie-core/src/sandbox.ts
@@ -4,6 +4,7 @@ import {
   recoverDocumentListeners,
   insertScriptToIframe,
   patchEventTimeStamp,
+  patchDegradeInstanceofAcrossRealms,
 } from "./iframe";
 import { syncUrlToWindow, syncUrlToIframe, clearInactiveAppUrl } from "./sync";
 import {
@@ -112,6 +113,13 @@ export default class Wujie {
    * 时登记，sandbox.destroy() 时统一从 iframe head detach 并清空。
    */
   public dynamicScriptElements: Array<HTMLScriptElement> = [];
+  /**
+   * 动态 <link rel=stylesheet> 以空 href 插入（先 appendChild 后 setAttribute('href')，
+   * 如 tinymce 的 StyleSheetLoader）时，effect.ts 会注册一个 MutationObserver 监听
+   * href 的后续赋值。这些 observer 必须在 destroy 时统一 disconnect，否则游离 link
+   * 会通过 node → registered observer → callback 闭包链路把已销毁的 sandbox 钉在内存中。
+   */
+  public deferredStyleObservers: Array<MutationObserver> = [];
   /** 子应用head元素 */
   public head: HTMLHeadElement;
   /** 子应用body元素 */
@@ -224,6 +232,10 @@ export default class Wujie {
         await renderTemplateToIframe(iframe.contentDocument, this.iframe.contentWindow, this.template);
       }
       this.document = iframe.contentDocument;
+      const renderWindow = this.document.defaultView;
+      if (renderWindow) {
+        patchDegradeInstanceofAcrossRealms(iframeWindow, renderWindow);
+      }
       return;
     }
 
@@ -378,6 +390,8 @@ export default class Wujie {
 
   /** 保活模式和使用proxyLocation.href跳转链接都不应该销毁shadow */
   public async unmount(): Promise<void> {
+    // 子应用卸载时 disconnect 等待 href 的 MutationObserver，避免闭包在 remount 前仍持有上下文
+    this.clearDeferredStyleObservers();
     this.activeFlag = false;
     // 清理子应用过期的同步参数
     clearInactiveAppUrl();
@@ -412,6 +426,8 @@ export default class Wujie {
     // 释放动态样式 / 脚本节点（unmount 阶段保留以便 rebuildStyleSheets 复用，destroy 阶段才彻底清）
     this.clearStyleSheets();
     this.clearDynamicScripts();
+    // 解绑等待 href 赋值的 MutationObserver，避免闭包钉住已销毁的 sandbox
+    this.clearDeferredStyleObservers();
     // 先 $destroy 再置 null：清空事件并从全局 appEventObjMap 中移除当前 id 的 entry，
     // 避免 setupApp → destroyApp 反复后 map 条目持续累积。
     this.bus.$destroy();
@@ -424,6 +440,7 @@ export default class Wujie {
     this.degradeAttrs = null;
     this.styleSheetElements = null;
     this.dynamicScriptElements = null;
+    this.deferredStyleObservers = null;
     this.bus = null;
     this.replace = null;
     this.fetch = null;
@@ -505,6 +522,23 @@ export default class Wujie {
       }
     });
     this.dynamicScriptElements.length = 0;
+  }
+
+  /**
+   * unmount / destroy 阶段统一 disconnect 等待 href 赋值的 MutationObserver。
+   * observer 在 href 命中或超时兜底时会自行 disconnect 并出队；
+   * 这里兜底处理「子应用先于 href 赋值被卸载/销毁」的场景。
+   */
+  public clearDeferredStyleObservers(): void {
+    if (!Array.isArray(this.deferredStyleObservers)) return;
+    this.deferredStyleObservers.forEach((observer) => {
+      try {
+        observer.disconnect();
+      } catch (_) {
+        /* noop: destroy 阶段任何异常不应中断后续清理 */
+      }
+    });
+    this.deferredStyleObservers.length = 0;
   }
 
   /** 当子应用再次激活后，只运行mount函数，样式需要重新恢复 */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -792,6 +792,12 @@ importers:
       '@popperjs/core':
         specifier: 2.11.8
         version: 2.11.8
+      '@wangeditor/editor':
+        specifier: ^5.1.23
+        version: 5.1.23
+      '@wangeditor/editor-for-vue':
+        specifier: ^1.0.2
+        version: 1.0.2(@wangeditor/editor@5.1.23)(vue@2.7.16)
       ant-design-vue:
         specifier: 1.7.8
         version: 1.7.8(vue-template-compiler@2.7.16)(vue@2.7.16)
@@ -804,6 +810,9 @@ importers:
       popper.js:
         specifier: 1.16.1
         version: 1.16.1
+      tinymce:
+        specifier: ^6.8.5
+        version: 6.8.6
       vue:
         specifier: ^2.6.11
         version: 2.7.16
@@ -3497,6 +3506,9 @@ packages:
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
     engines: {node: '>= 10'}
 
+  '@transloadit/prettier-bytes@0.0.7':
+    resolution: {integrity: sha512-VeJbUb0wEKbcwaSlj5n+LscBl9IPgLPkHVGBkh00cztv6X4L/TJXK58LzFuBKX7/GAfiGhIwH67YTLTlzvIzBA==}
+
   '@trysound/sax@0.2.0':
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
     engines: {node: '>=10.13.0'}
@@ -3574,6 +3586,9 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/event-emitter@0.3.5':
+    resolution: {integrity: sha512-zx2/Gg0Eg7gwEiOIIh5w9TrhKKTeQh7CPCOPNc0el4pLSwzebA8SmnHwZs2dWlLONvyulykSwGSQxQHLhjGLvQ==}
 
   '@types/express-serve-static-core@4.19.7':
     resolution: {integrity: sha512-FvPtiIf1LfhzsaIXhv/PHan/2FeQBbtBDtfX2QfvPxdUelMDEckK08SM6nqo1MIZY3RUlfA+HV8+hFUSio78qg==}
@@ -3917,6 +3932,23 @@ packages:
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
+  '@uppy/companion-client@2.2.2':
+    resolution: {integrity: sha512-5mTp2iq97/mYSisMaBtFRry6PTgZA6SIL7LePteOV5x0/DxKfrZW3DEiQERJmYpHzy7k8johpm2gHnEKto56Og==}
+
+  '@uppy/core@2.3.4':
+    resolution: {integrity: sha512-iWAqppC8FD8mMVqewavCz+TNaet6HPXitmGXpGGREGrakZ4FeuWytVdrelydzTdXx6vVKkOmI2FLztGg73sENQ==}
+
+  '@uppy/store-default@2.1.1':
+    resolution: {integrity: sha512-xnpTxvot2SeAwGwbvmJ899ASk5tYXhmZzD/aCFsXePh/v8rNvR2pKlcQUH7cF/y4baUGq3FHO/daKCok/mpKqQ==}
+
+  '@uppy/utils@4.1.3':
+    resolution: {integrity: sha512-nTuMvwWYobnJcytDO3t+D6IkVq/Qs4Xv3vyoEZ+Iaf8gegZP+rEyoaFT2CK5XLRMienPyqRqNbIfRuFaOWSIFw==}
+
+  '@uppy/xhr-upload@2.1.3':
+    resolution: {integrity: sha512-YWOQ6myBVPs+mhNjfdWsQyMRWUlrDLMoaG7nvf/G6Y3GKZf8AyjFDjvvJ49XWQ+DaZOftGkHmF1uh/DBeGivJQ==}
+    peerDependencies:
+      '@uppy/core': ^2.3.3
+
   '@vitejs/plugin-vue@2.3.4':
     resolution: {integrity: sha512-IfFNbtkbIm36O9KB8QodlwwYvTEsJb4Lll4c2IwB3VHc2gie2mSPtSzL0eYay7X2jd/2WX02FjSGTWR6OPr/zg==}
     engines: {node: '>=12.0.0'}
@@ -4175,6 +4207,93 @@ packages:
 
   '@vueuse/shared@9.13.0':
     resolution: {integrity: sha512-UrnhU+Cnufu4S6JLCPZnkWh0WwZGUp72ktOF2DFptMlOs3TOdVv8xJN53zhHGARmVOsz5KqOls09+J1NR6sBKw==}
+
+  '@wangeditor/basic-modules@1.1.7':
+    resolution: {integrity: sha512-cY9CPkLJaqF05STqfpZKWG4LpxTMeGSIIF1fHvfm/mz+JXatCagjdkbxdikOuKYlxDdeqvOeBmsUBItufDLXZg==}
+    peerDependencies:
+      '@wangeditor/core': 1.x
+      dom7: ^3.0.0
+      lodash.throttle: ^4.1.1
+      nanoid: ^3.2.0
+      slate: ^0.72.0
+      snabbdom: ^3.1.0
+
+  '@wangeditor/code-highlight@1.0.3':
+    resolution: {integrity: sha512-iazHwO14XpCuIWJNTQTikqUhGKyqj+dUNWJ9288Oym9M2xMVHvnsOmDU2sgUDWVy+pOLojReMPgXCsvvNlOOhw==}
+    peerDependencies:
+      '@wangeditor/core': 1.x
+      dom7: ^3.0.0
+      slate: ^0.72.0
+      snabbdom: ^3.1.0
+
+  '@wangeditor/core@1.1.19':
+    resolution: {integrity: sha512-KevkB47+7GhVszyYF2pKGKtCSj/YzmClsD03C3zTt+9SR2XWT5T0e3yQqg8baZpcMvkjs1D8Dv4fk8ok/UaS2Q==}
+    peerDependencies:
+      '@uppy/core': ^2.1.1
+      '@uppy/xhr-upload': ^2.0.3
+      dom7: ^3.0.0
+      is-hotkey: ^0.2.0
+      lodash.camelcase: ^4.3.0
+      lodash.clonedeep: ^4.5.0
+      lodash.debounce: ^4.0.8
+      lodash.foreach: ^4.5.0
+      lodash.isequal: ^4.5.0
+      lodash.throttle: ^4.1.1
+      lodash.toarray: ^4.4.0
+      nanoid: ^3.2.0
+      slate: ^0.72.0
+      snabbdom: ^3.1.0
+
+  '@wangeditor/editor-for-vue@1.0.2':
+    resolution: {integrity: sha512-BOENvAXJVtVXlE2X50AAvjV82YlCUeu5cbeR0cvEQHQjYtiVnJtq7HSoj85r2kTgGouI5OrpJG9BBEjSjUSPyA==}
+    peerDependencies:
+      '@wangeditor/editor': '>=5.1.0'
+      vue: ^2.6.14
+
+  '@wangeditor/editor@5.1.23':
+    resolution: {integrity: sha512-0RxfeVTuK1tktUaPROnCoFfaHVJpRAIE2zdS0mpP+vq1axVQpLjM8+fCvKzqYIkH0Pg+C+44hJpe3VVroSkEuQ==}
+
+  '@wangeditor/list-module@1.0.5':
+    resolution: {integrity: sha512-uDuYTP6DVhcYf7mF1pTlmNn5jOb4QtcVhYwSSAkyg09zqxI1qBqsfUnveeDeDqIuptSJhkh81cyxi+MF8sEPOQ==}
+    peerDependencies:
+      '@wangeditor/core': 1.x
+      dom7: ^3.0.0
+      slate: ^0.72.0
+      snabbdom: ^3.1.0
+
+  '@wangeditor/table-module@1.1.4':
+    resolution: {integrity: sha512-5saanU9xuEocxaemGdNi9t8MCDSucnykEC6jtuiT72kt+/Hhh4nERYx1J20OPsTCCdVr7hIyQenFD1iSRkIQ6w==}
+    peerDependencies:
+      '@wangeditor/core': 1.x
+      dom7: ^3.0.0
+      lodash.isequal: ^4.5.0
+      lodash.throttle: ^4.1.1
+      nanoid: ^3.2.0
+      slate: ^0.72.0
+      snabbdom: ^3.1.0
+
+  '@wangeditor/upload-image-module@1.0.2':
+    resolution: {integrity: sha512-z81lk/v71OwPDYeQDxj6cVr81aDP90aFuywb8nPD6eQeECtOymrqRODjpO6VGvCVxVck8nUxBHtbxKtjgcwyiA==}
+    peerDependencies:
+      '@uppy/core': ^2.0.3
+      '@uppy/xhr-upload': ^2.0.3
+      '@wangeditor/basic-modules': 1.x
+      '@wangeditor/core': 1.x
+      dom7: ^3.0.0
+      lodash.foreach: ^4.5.0
+      slate: ^0.72.0
+      snabbdom: ^3.1.0
+
+  '@wangeditor/video-module@1.1.4':
+    resolution: {integrity: sha512-ZdodDPqKQrgx3IwWu4ZiQmXI8EXZ3hm2/fM6E3t5dB8tCaIGWQZhmqd6P5knfkRAd3z2+YRSRbxOGfoRSp/rLg==}
+    peerDependencies:
+      '@uppy/core': ^2.1.4
+      '@uppy/xhr-upload': ^2.0.7
+      '@wangeditor/core': 1.x
+      dom7: ^3.0.0
+      nanoid: ^3.2.0
+      slate: ^0.72.0
+      snabbdom: ^3.1.0
 
   '@webassemblyjs/ast@1.11.1':
     resolution: {integrity: sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==}
@@ -6494,6 +6613,9 @@ packages:
   dom-serializer@1.4.1:
     resolution: {integrity: sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==}
 
+  dom7@3.0.0:
+    resolution: {integrity: sha512-oNlcUdHsC4zb7Msx7JN3K0Nro1dzJ48knvBOnDPKJ2GV9wl1i5vydJZUSyOfrkKFDZEud/jBsTk92S/VGSAe/g==}
+
   domain-browser@1.2.0:
     resolution: {integrity: sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==}
     engines: {node: '>=0.4', npm: '>=1.2'}
@@ -8315,6 +8437,9 @@ packages:
     resolution: {integrity: sha512-+Il6N8cCo2wB/Vd3gqy/8TZhTD3QvcVeQLCnZiGkGCH3JP28IgGAY41giccp2W4R3jfyJPAP318FQTa1yU7K7g==}
     engines: {node: '>=4'}
 
+  html-void-elements@2.0.1:
+    resolution: {integrity: sha512-0quDb7s97CfemeJAnW9wC0hw78MtW7NU3hqtCD75g2vFlDLt36llsYD7uB7SUzojLMP24N5IatXf7ylGXiGG9A==}
+
   html-webpack-plugin@3.2.0:
     resolution: {integrity: sha512-Br4ifmjQojUP4EmHnRBoUIYcZ9J7M4bTMcm7u6xoIAIuq2Nte4TzXX0533owvkQKQD1WeMTTTyD4Ni4QKxS0Bg==}
     engines: {node: '>=6.9'}
@@ -8426,6 +8551,9 @@ packages:
     resolution: {integrity: sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==}
     engines: {node: '>=12'}
     hasBin: true
+
+  i18next@20.6.1:
+    resolution: {integrity: sha512-yCMYTMEJ9ihCwEQQ3phLo7I/Pwycf8uAx+sRHwwk5U9Aui/IZYgQRyMqXafQOw5QQ7DM1Z+WyEXWIqSuJHhG2A==}
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
@@ -8742,6 +8870,9 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-hotkey@0.2.0:
+    resolution: {integrity: sha512-UknnZK4RakDmTgz4PI1wIph5yxSs/mvChWs9ifnlXsKuXgWmOkY/hAE0H/k2MIqH0RlRye0i1oC07MCRSD28Mw==}
+
   is-interactive@1.0.0:
     resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
     engines: {node: '>=8'}
@@ -8889,6 +9020,9 @@ packages:
   is-unicode-supported@0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
+
+  is-url@1.2.4:
+    resolution: {integrity: sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==}
 
   is-weakmap@2.0.2:
     resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
@@ -9538,11 +9672,24 @@ packages:
   lodash._reinterpolate@3.0.0:
     resolution: {integrity: sha512-xYHt68QRoYGjeeM/XOE1uJtvXQAgvszfBhjV4yvsQH0u2i9I6cI6c6/eG4Hh3UAOVn0y/xAXwmTzEay49Q//HA==}
 
+  lodash.camelcase@4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
+  lodash.clonedeep@4.5.0:
+    resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
+
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
 
   lodash.defaultsdeep@4.6.1:
     resolution: {integrity: sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA==}
+
+  lodash.foreach@4.5.0:
+    resolution: {integrity: sha512-aEXTF4d+m05rVOAUG3z4vZZ4xVexLKZGF0lIxuHZ1Hplpk/3B6Z1+/ICICYRLm7c41Z2xiejbkCkJoTlypoXhQ==}
+
+  lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash.ismatch@4.4.0:
     resolution: {integrity: sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g==}
@@ -9568,6 +9715,12 @@ packages:
 
   lodash.templatesettings@4.2.0:
     resolution: {integrity: sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==}
+
+  lodash.throttle@4.1.1:
+    resolution: {integrity: sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==}
+
+  lodash.toarray@4.4.0:
+    resolution: {integrity: sha512-QyffEA3i5dma5q2490+SgCvDN0pXLmRGSyAANuVi0HQ01Pkfr9fuoKQW8wm1wGBnJITs/mS7wQvS6VshUEBFCw==}
 
   lodash.transform@4.6.0:
     resolution: {integrity: sha512-LO37ZnhmBVx0GvOU/caQuipEh4GN82TcWv3yHlebGDgOxbxiwwzW5Pcx2AcvpIv2WmvmSMoC492yQFNhy/l/UQ==}
@@ -9784,6 +9937,9 @@ packages:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
     engines: {node: '>= 0.6'}
 
+  mime-match@1.0.2:
+    resolution: {integrity: sha512-VXp/ugGDVh3eCLOBCiHZMYWQaTNUHv2IJrut+yXA6+JbLPXHglHwfS/5A5L0ll+jkCY7fIzRJcH6OIunF+c6Cg==}
+
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
@@ -9995,6 +10151,9 @@ packages:
 
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  namespace-emitter@2.0.1:
+    resolution: {integrity: sha512-N/sMKHniSDJBjfrkbS/tpkPj4RAbvW3mr8UAzvlMHyun93XEm83IAvhWtJVHo+RHn/oO8Job5YN4b+wRjSVp5g==}
 
   nan@2.23.0:
     resolution: {integrity: sha512-1UxuyYGdoQHcGg87Lkqm3FzefucTa0NAiOcuRsDmysep3c1LVCRK2krrUDafMWtjSG04htvAmvg96+SDknOmgQ==}
@@ -11520,6 +11679,10 @@ packages:
     resolution: {integrity: sha512-8gFb/To0OmxHR9+ZTb14Df2vNxdGCX8g1xWGUTqUw5TiZvcQf5sHKObd5UcPyLLyowNwDAMTF3XWOG1B6mxl1Q==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
 
+  prismjs@1.30.0:
+    resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
+    engines: {node: '>=6'}
+
   proc-log@3.0.0:
     resolution: {integrity: sha512-++Vn7NS4Xf9NacaU9Xq3URUuqZETPsf8L4j5/ckhaRYsfPeRyzGw+iDjFhV/Jr3uNmTvvddEJFWh5R1gRgUH8A==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -12854,6 +13017,14 @@ packages:
     resolution: {integrity: sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==}
     engines: {node: '>=12'}
 
+  slate-history@0.66.0:
+    resolution: {integrity: sha512-6MWpxGQZiMvSINlCbMW43E2YBSVMCMCIwQfBzGssjWw4kb0qfvj0pIdblWNRQZD0hR6WHP+dHHgGSeVdMWzfng==}
+    peerDependencies:
+      slate: '>=0.65.3'
+
+  slate@0.72.8:
+    resolution: {integrity: sha512-/nJwTswQgnRurpK+bGJFH1oM7naD5qDmHd89JyiKNT2oOKD8marW0QSBtuFnwEbL5aGCS8AmrhXQgNOsn4osAw==}
+
   slice-ansi@2.1.0:
     resolution: {integrity: sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==}
     engines: {node: '>=6'}
@@ -12873,6 +13044,10 @@ packages:
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
+  snabbdom@3.6.3:
+    resolution: {integrity: sha512-W2lHLLw2qR2Vv0DcMmcxXqcfdBaIcoN+y/86SmHv8fn4DazEQSH6KN3TjZcWvwujW56OHiiirsbHWZb4vx/0fg==}
+    engines: {node: '>=12.17.0'}
 
   snapdragon-node@2.1.1:
     resolution: {integrity: sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==}
@@ -13032,6 +13207,9 @@ packages:
     resolution: {integrity: sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==}
     engines: {node: '>=0.10.0'}
     hasBin: true
+
+  ssr-window@3.0.0:
+    resolution: {integrity: sha512-q+8UfWDg9Itrg0yWK7oe5p/XRCJpJF9OBtXfOPgSJl+u3Xd5KI328RUEvUqSMVM9CiQUEf1QdBzJMkYGErj9QA==}
 
   ssri@10.0.6:
     resolution: {integrity: sha512-MGrFH9Z4NP9Iyhqn16sDtBpRRNJ0Y2hNa6D65h736fVSaPCHr4DM4sWUNvVaSuC+0OBGhwsrydQwmgfg5LncqQ==}
@@ -13491,6 +13669,9 @@ packages:
 
   tinycolor2@1.6.0:
     resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
+
+  tinymce@6.8.6:
+    resolution: {integrity: sha512-++XYEs8lKWvZxDCjrr8Baiw7KiikraZ5JkLMg6EdnUVNKJui0IsrAADj5MsyUeFkcEryfn2jd3p09H7REvewyg==}
 
   tmp@0.0.33:
     resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
@@ -14510,6 +14691,9 @@ packages:
   wide-align@1.1.5:
     resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
 
+  wildcard@1.1.2:
+    resolution: {integrity: sha512-DXukZJxpHA8LuotRwL0pP1+rS6CS7FF2qStDDE1C7DDg2rLud2PXRMuEDYIPhgEezwnlHNL4c+N6MfMTjCGTng==}
+
   wildcard@2.0.1:
     resolution: {integrity: sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==}
 
@@ -15309,7 +15493,7 @@ snapshots:
       '@babel/traverse': 7.28.4
       '@babel/types': 7.28.4
       convert-source-map: 1.9.0
-      debug: 4.4.3(supports-color@6.1.0)
+      debug: 4.4.3(supports-color@9.4.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       lodash: 4.17.21
@@ -15331,7 +15515,7 @@ snapshots:
       '@babel/traverse': 7.28.4
       '@babel/types': 7.28.4
       convert-source-map: 1.9.0
-      debug: 4.4.3(supports-color@6.1.0)
+      debug: 4.4.3(supports-color@9.4.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -15349,7 +15533,7 @@ snapshots:
       '@babel/traverse': 7.28.4
       '@babel/types': 7.28.4
       convert-source-map: 1.9.0
-      debug: 4.4.3(supports-color@6.1.0)
+      debug: 4.4.3(supports-color@9.4.0)
       json5: 2.2.3
       lodash: 4.17.21
       resolve: 1.22.10
@@ -15371,7 +15555,7 @@ snapshots:
       '@babel/types': 7.28.4
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@6.1.0)
+      debug: 4.4.3(supports-color@9.4.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -15488,7 +15672,7 @@ snapshots:
       '@babel/helper-module-imports': 7.27.1
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/traverse': 7.28.4
-      debug: 4.4.3(supports-color@6.1.0)
+      debug: 4.4.3(supports-color@9.4.0)
       lodash.debounce: 4.0.8
       resolve: 1.22.10
       semver: 6.3.1
@@ -15500,7 +15684,7 @@ snapshots:
       '@babel/core': 7.28.4
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
-      debug: 4.4.3(supports-color@6.1.0)
+      debug: 4.4.3(supports-color@9.4.0)
       lodash.debounce: 4.0.8
       resolve: 1.22.10
     transitivePeerDependencies:
@@ -17409,7 +17593,7 @@ snapshots:
       '@babel/parser': 7.28.4
       '@babel/template': 7.27.2
       '@babel/types': 7.28.4
-      debug: 4.4.3(supports-color@6.1.0)
+      debug: 4.4.3(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -17771,7 +17955,7 @@ snapshots:
   '@eslint/eslintrc@0.2.2':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.3(supports-color@6.1.0)
+      debug: 4.4.3(supports-color@9.4.0)
       espree: 7.3.1
       globals: 12.4.0
       ignore: 4.0.6
@@ -17786,7 +17970,7 @@ snapshots:
   '@eslint/eslintrc@0.4.3':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.3(supports-color@6.1.0)
+      debug: 4.4.3(supports-color@9.4.0)
       espree: 7.3.1
       globals: 13.24.0
       ignore: 4.0.6
@@ -17800,7 +17984,7 @@ snapshots:
   '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.3(supports-color@6.1.0)
+      debug: 4.4.3(supports-color@9.4.0)
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
@@ -17852,7 +18036,7 @@ snapshots:
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.4.3(supports-color@6.1.0)
+      debug: 4.4.3(supports-color@9.4.0)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -17860,7 +18044,7 @@ snapshots:
   '@humanwhocodes/config-array@0.5.0':
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.4.3(supports-color@6.1.0)
+      debug: 4.4.3(supports-color@9.4.0)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -18953,6 +19137,8 @@ snapshots:
 
   '@tootallnate/once@2.0.0': {}
 
+  '@transloadit/prettier-bytes@0.0.7': {}
+
   '@trysound/sax@0.2.0': {}
 
   '@tsconfig/node10@1.0.11': {}
@@ -19042,6 +19228,8 @@ snapshots:
   '@types/estree@0.0.50': {}
 
   '@types/estree@1.0.8': {}
+
+  '@types/event-emitter@0.3.5': {}
 
   '@types/express-serve-static-core@4.19.7':
     dependencies:
@@ -19306,7 +19494,7 @@ snapshots:
       '@typescript-eslint/experimental-utils': 4.33.0(eslint@7.32.0)(typescript@4.9.5)
       '@typescript-eslint/parser': 4.33.0(eslint@7.32.0)(typescript@4.9.5)
       '@typescript-eslint/scope-manager': 4.33.0
-      debug: 4.4.3(supports-color@6.1.0)
+      debug: 4.4.3(supports-color@9.4.0)
       eslint: 7.32.0
       functional-red-black-tree: 1.0.1
       ignore: 5.3.2
@@ -19325,7 +19513,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/type-utils': 5.62.0(eslint@8.57.1)(typescript@4.9.5)
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@4.9.5)
-      debug: 4.4.3(supports-color@6.1.0)
+      debug: 4.4.3(supports-color@9.4.0)
       eslint: 8.57.1
       graphemer: 1.4.0
       ignore: 5.3.2
@@ -19375,7 +19563,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 4.33.0
       '@typescript-eslint/types': 4.33.0
       '@typescript-eslint/typescript-estree': 4.33.0(typescript@4.9.5)
-      debug: 4.4.3(supports-color@6.1.0)
+      debug: 4.4.3(supports-color@9.4.0)
       eslint: 7.32.0
     optionalDependencies:
       typescript: 4.9.5
@@ -19387,7 +19575,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.9.5)
-      debug: 4.4.3(supports-color@6.1.0)
+      debug: 4.4.3(supports-color@9.4.0)
       eslint: 8.57.1
     optionalDependencies:
       typescript: 4.9.5
@@ -19408,7 +19596,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.9.5)
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@4.9.5)
-      debug: 4.4.3(supports-color@6.1.0)
+      debug: 4.4.3(supports-color@9.4.0)
       eslint: 8.57.1
       tsutils: 3.21.0(typescript@4.9.5)
     optionalDependencies:
@@ -19426,7 +19614,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 3.10.1
       '@typescript-eslint/visitor-keys': 3.10.1
-      debug: 4.4.3(supports-color@6.1.0)
+      debug: 4.4.3(supports-color@9.4.0)
       glob: 7.2.3
       is-glob: 4.0.3
       lodash: 4.17.21
@@ -19441,7 +19629,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 4.33.0
       '@typescript-eslint/visitor-keys': 4.33.0
-      debug: 4.4.3(supports-color@6.1.0)
+      debug: 4.4.3(supports-color@9.4.0)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.2
@@ -19455,7 +19643,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.4.3(supports-color@6.1.0)
+      debug: 4.4.3(supports-color@9.4.0)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.2
@@ -19495,6 +19683,35 @@ snapshots:
       eslint-visitor-keys: 3.4.3
 
   '@ungap/structured-clone@1.3.0': {}
+
+  '@uppy/companion-client@2.2.2':
+    dependencies:
+      '@uppy/utils': 4.1.3
+      namespace-emitter: 2.0.1
+
+  '@uppy/core@2.3.4':
+    dependencies:
+      '@transloadit/prettier-bytes': 0.0.7
+      '@uppy/store-default': 2.1.1
+      '@uppy/utils': 4.1.3
+      lodash.throttle: 4.1.1
+      mime-match: 1.0.2
+      namespace-emitter: 2.0.1
+      nanoid: 3.3.11
+      preact: 10.27.2
+
+  '@uppy/store-default@2.1.1': {}
+
+  '@uppy/utils@4.1.3':
+    dependencies:
+      lodash.throttle: 4.1.1
+
+  '@uppy/xhr-upload@2.1.3(@uppy/core@2.3.4)':
+    dependencies:
+      '@uppy/companion-client': 2.2.2
+      '@uppy/core': 2.3.4
+      '@uppy/utils': 4.1.3
+      nanoid: 3.3.11
 
   '@vitejs/plugin-vue@2.3.4(vite@2.9.18(less@4.1.1)(sass@1.36.0)(stylus@0.54.8))(vue@3.5.22(typescript@4.9.5))':
     dependencies:
@@ -19840,7 +20057,7 @@ snapshots:
       copy-webpack-plugin: 5.1.2(webpack@4.44.2)
       css-loader: 3.6.0(webpack@4.44.2)
       cssnano: 4.1.11
-      debug: 4.4.3(supports-color@6.1.0)
+      debug: 4.4.3(supports-color@9.4.0)
       default-gateway: 5.0.5
       dotenv: 8.2.0
       dotenv-expand: 5.1.0
@@ -19856,7 +20073,7 @@ snapshots:
       mini-css-extract-plugin: 0.9.0(webpack@4.44.2)
       minimist: 1.2.8
       pnp-webpack-plugin: 1.6.4(typescript@4.9.5)
-      portfinder: 1.0.38(supports-color@6.1.0)
+      portfinder: 1.0.38
       postcss-loader: 3.0.0
       ssri: 8.0.1
       terser-webpack-plugin: 1.4.6(webpack@4.44.2)
@@ -19964,7 +20181,7 @@ snapshots:
       copy-webpack-plugin: 5.1.2(webpack@4.44.2)
       css-loader: 3.6.0(webpack@4.44.2)
       cssnano: 4.1.11
-      debug: 4.4.3(supports-color@6.1.0)
+      debug: 4.4.3(supports-color@9.4.0)
       default-gateway: 5.0.5
       dotenv: 8.2.0
       dotenv-expand: 5.1.0
@@ -19980,7 +20197,7 @@ snapshots:
       mini-css-extract-plugin: 0.9.0(webpack@4.44.2)
       minimist: 1.2.8
       pnp-webpack-plugin: 1.6.4(typescript@4.9.5)
-      portfinder: 1.0.38(supports-color@6.1.0)
+      portfinder: 1.0.38
       postcss-loader: 3.0.0
       ssri: 8.0.1
       terser-webpack-plugin: 1.4.6(webpack@4.44.2)
@@ -20278,6 +20495,114 @@ snapshots:
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
+
+  '@wangeditor/basic-modules@1.1.7(@wangeditor/core@1.1.19(@uppy/core@2.3.4)(@uppy/xhr-upload@2.1.3(@uppy/core@2.3.4))(dom7@3.0.0)(is-hotkey@0.2.0)(lodash.camelcase@4.3.0)(lodash.clonedeep@4.5.0)(lodash.debounce@4.0.8)(lodash.foreach@4.5.0)(lodash.isequal@4.5.0)(lodash.throttle@4.1.1)(lodash.toarray@4.4.0)(nanoid@3.3.11)(slate@0.72.8)(snabbdom@3.6.3))(dom7@3.0.0)(lodash.throttle@4.1.1)(nanoid@3.3.11)(slate@0.72.8)(snabbdom@3.6.3)':
+    dependencies:
+      '@wangeditor/core': 1.1.19(@uppy/core@2.3.4)(@uppy/xhr-upload@2.1.3(@uppy/core@2.3.4))(dom7@3.0.0)(is-hotkey@0.2.0)(lodash.camelcase@4.3.0)(lodash.clonedeep@4.5.0)(lodash.debounce@4.0.8)(lodash.foreach@4.5.0)(lodash.isequal@4.5.0)(lodash.throttle@4.1.1)(lodash.toarray@4.4.0)(nanoid@3.3.11)(slate@0.72.8)(snabbdom@3.6.3)
+      dom7: 3.0.0
+      is-url: 1.2.4
+      lodash.throttle: 4.1.1
+      nanoid: 3.3.11
+      slate: 0.72.8
+      snabbdom: 3.6.3
+
+  '@wangeditor/code-highlight@1.0.3(@wangeditor/core@1.1.19(@uppy/core@2.3.4)(@uppy/xhr-upload@2.1.3(@uppy/core@2.3.4))(dom7@3.0.0)(is-hotkey@0.2.0)(lodash.camelcase@4.3.0)(lodash.clonedeep@4.5.0)(lodash.debounce@4.0.8)(lodash.foreach@4.5.0)(lodash.isequal@4.5.0)(lodash.throttle@4.1.1)(lodash.toarray@4.4.0)(nanoid@3.3.11)(slate@0.72.8)(snabbdom@3.6.3))(dom7@3.0.0)(slate@0.72.8)(snabbdom@3.6.3)':
+    dependencies:
+      '@wangeditor/core': 1.1.19(@uppy/core@2.3.4)(@uppy/xhr-upload@2.1.3(@uppy/core@2.3.4))(dom7@3.0.0)(is-hotkey@0.2.0)(lodash.camelcase@4.3.0)(lodash.clonedeep@4.5.0)(lodash.debounce@4.0.8)(lodash.foreach@4.5.0)(lodash.isequal@4.5.0)(lodash.throttle@4.1.1)(lodash.toarray@4.4.0)(nanoid@3.3.11)(slate@0.72.8)(snabbdom@3.6.3)
+      dom7: 3.0.0
+      prismjs: 1.30.0
+      slate: 0.72.8
+      snabbdom: 3.6.3
+
+  '@wangeditor/core@1.1.19(@uppy/core@2.3.4)(@uppy/xhr-upload@2.1.3(@uppy/core@2.3.4))(dom7@3.0.0)(is-hotkey@0.2.0)(lodash.camelcase@4.3.0)(lodash.clonedeep@4.5.0)(lodash.debounce@4.0.8)(lodash.foreach@4.5.0)(lodash.isequal@4.5.0)(lodash.throttle@4.1.1)(lodash.toarray@4.4.0)(nanoid@3.3.11)(slate@0.72.8)(snabbdom@3.6.3)':
+    dependencies:
+      '@types/event-emitter': 0.3.5
+      '@uppy/core': 2.3.4
+      '@uppy/xhr-upload': 2.1.3(@uppy/core@2.3.4)
+      dom7: 3.0.0
+      event-emitter: 0.3.5
+      html-void-elements: 2.0.1
+      i18next: 20.6.1
+      is-hotkey: 0.2.0
+      lodash.camelcase: 4.3.0
+      lodash.clonedeep: 4.5.0
+      lodash.debounce: 4.0.8
+      lodash.foreach: 4.5.0
+      lodash.isequal: 4.5.0
+      lodash.throttle: 4.1.1
+      lodash.toarray: 4.4.0
+      nanoid: 3.3.11
+      scroll-into-view-if-needed: 2.2.31
+      slate: 0.72.8
+      slate-history: 0.66.0(slate@0.72.8)
+      snabbdom: 3.6.3
+
+  '@wangeditor/editor-for-vue@1.0.2(@wangeditor/editor@5.1.23)(vue@2.7.16)':
+    dependencies:
+      '@wangeditor/editor': 5.1.23
+      vue: 2.7.16
+
+  '@wangeditor/editor@5.1.23':
+    dependencies:
+      '@uppy/core': 2.3.4
+      '@uppy/xhr-upload': 2.1.3(@uppy/core@2.3.4)
+      '@wangeditor/basic-modules': 1.1.7(@wangeditor/core@1.1.19(@uppy/core@2.3.4)(@uppy/xhr-upload@2.1.3(@uppy/core@2.3.4))(dom7@3.0.0)(is-hotkey@0.2.0)(lodash.camelcase@4.3.0)(lodash.clonedeep@4.5.0)(lodash.debounce@4.0.8)(lodash.foreach@4.5.0)(lodash.isequal@4.5.0)(lodash.throttle@4.1.1)(lodash.toarray@4.4.0)(nanoid@3.3.11)(slate@0.72.8)(snabbdom@3.6.3))(dom7@3.0.0)(lodash.throttle@4.1.1)(nanoid@3.3.11)(slate@0.72.8)(snabbdom@3.6.3)
+      '@wangeditor/code-highlight': 1.0.3(@wangeditor/core@1.1.19(@uppy/core@2.3.4)(@uppy/xhr-upload@2.1.3(@uppy/core@2.3.4))(dom7@3.0.0)(is-hotkey@0.2.0)(lodash.camelcase@4.3.0)(lodash.clonedeep@4.5.0)(lodash.debounce@4.0.8)(lodash.foreach@4.5.0)(lodash.isequal@4.5.0)(lodash.throttle@4.1.1)(lodash.toarray@4.4.0)(nanoid@3.3.11)(slate@0.72.8)(snabbdom@3.6.3))(dom7@3.0.0)(slate@0.72.8)(snabbdom@3.6.3)
+      '@wangeditor/core': 1.1.19(@uppy/core@2.3.4)(@uppy/xhr-upload@2.1.3(@uppy/core@2.3.4))(dom7@3.0.0)(is-hotkey@0.2.0)(lodash.camelcase@4.3.0)(lodash.clonedeep@4.5.0)(lodash.debounce@4.0.8)(lodash.foreach@4.5.0)(lodash.isequal@4.5.0)(lodash.throttle@4.1.1)(lodash.toarray@4.4.0)(nanoid@3.3.11)(slate@0.72.8)(snabbdom@3.6.3)
+      '@wangeditor/list-module': 1.0.5(@wangeditor/core@1.1.19(@uppy/core@2.3.4)(@uppy/xhr-upload@2.1.3(@uppy/core@2.3.4))(dom7@3.0.0)(is-hotkey@0.2.0)(lodash.camelcase@4.3.0)(lodash.clonedeep@4.5.0)(lodash.debounce@4.0.8)(lodash.foreach@4.5.0)(lodash.isequal@4.5.0)(lodash.throttle@4.1.1)(lodash.toarray@4.4.0)(nanoid@3.3.11)(slate@0.72.8)(snabbdom@3.6.3))(dom7@3.0.0)(slate@0.72.8)(snabbdom@3.6.3)
+      '@wangeditor/table-module': 1.1.4(@wangeditor/core@1.1.19(@uppy/core@2.3.4)(@uppy/xhr-upload@2.1.3(@uppy/core@2.3.4))(dom7@3.0.0)(is-hotkey@0.2.0)(lodash.camelcase@4.3.0)(lodash.clonedeep@4.5.0)(lodash.debounce@4.0.8)(lodash.foreach@4.5.0)(lodash.isequal@4.5.0)(lodash.throttle@4.1.1)(lodash.toarray@4.4.0)(nanoid@3.3.11)(slate@0.72.8)(snabbdom@3.6.3))(dom7@3.0.0)(lodash.isequal@4.5.0)(lodash.throttle@4.1.1)(nanoid@3.3.11)(slate@0.72.8)(snabbdom@3.6.3)
+      '@wangeditor/upload-image-module': 1.0.2(@uppy/core@2.3.4)(@uppy/xhr-upload@2.1.3(@uppy/core@2.3.4))(@wangeditor/basic-modules@1.1.7(@wangeditor/core@1.1.19(@uppy/core@2.3.4)(@uppy/xhr-upload@2.1.3(@uppy/core@2.3.4))(dom7@3.0.0)(is-hotkey@0.2.0)(lodash.camelcase@4.3.0)(lodash.clonedeep@4.5.0)(lodash.debounce@4.0.8)(lodash.foreach@4.5.0)(lodash.isequal@4.5.0)(lodash.throttle@4.1.1)(lodash.toarray@4.4.0)(nanoid@3.3.11)(slate@0.72.8)(snabbdom@3.6.3))(dom7@3.0.0)(lodash.throttle@4.1.1)(nanoid@3.3.11)(slate@0.72.8)(snabbdom@3.6.3))(@wangeditor/core@1.1.19(@uppy/core@2.3.4)(@uppy/xhr-upload@2.1.3(@uppy/core@2.3.4))(dom7@3.0.0)(is-hotkey@0.2.0)(lodash.camelcase@4.3.0)(lodash.clonedeep@4.5.0)(lodash.debounce@4.0.8)(lodash.foreach@4.5.0)(lodash.isequal@4.5.0)(lodash.throttle@4.1.1)(lodash.toarray@4.4.0)(nanoid@3.3.11)(slate@0.72.8)(snabbdom@3.6.3))(dom7@3.0.0)(lodash.foreach@4.5.0)(slate@0.72.8)(snabbdom@3.6.3)
+      '@wangeditor/video-module': 1.1.4(@uppy/core@2.3.4)(@uppy/xhr-upload@2.1.3(@uppy/core@2.3.4))(@wangeditor/core@1.1.19(@uppy/core@2.3.4)(@uppy/xhr-upload@2.1.3(@uppy/core@2.3.4))(dom7@3.0.0)(is-hotkey@0.2.0)(lodash.camelcase@4.3.0)(lodash.clonedeep@4.5.0)(lodash.debounce@4.0.8)(lodash.foreach@4.5.0)(lodash.isequal@4.5.0)(lodash.throttle@4.1.1)(lodash.toarray@4.4.0)(nanoid@3.3.11)(slate@0.72.8)(snabbdom@3.6.3))(dom7@3.0.0)(nanoid@3.3.11)(slate@0.72.8)(snabbdom@3.6.3)
+      dom7: 3.0.0
+      is-hotkey: 0.2.0
+      lodash.camelcase: 4.3.0
+      lodash.clonedeep: 4.5.0
+      lodash.debounce: 4.0.8
+      lodash.foreach: 4.5.0
+      lodash.isequal: 4.5.0
+      lodash.throttle: 4.1.1
+      lodash.toarray: 4.4.0
+      nanoid: 3.3.11
+      slate: 0.72.8
+      snabbdom: 3.6.3
+
+  '@wangeditor/list-module@1.0.5(@wangeditor/core@1.1.19(@uppy/core@2.3.4)(@uppy/xhr-upload@2.1.3(@uppy/core@2.3.4))(dom7@3.0.0)(is-hotkey@0.2.0)(lodash.camelcase@4.3.0)(lodash.clonedeep@4.5.0)(lodash.debounce@4.0.8)(lodash.foreach@4.5.0)(lodash.isequal@4.5.0)(lodash.throttle@4.1.1)(lodash.toarray@4.4.0)(nanoid@3.3.11)(slate@0.72.8)(snabbdom@3.6.3))(dom7@3.0.0)(slate@0.72.8)(snabbdom@3.6.3)':
+    dependencies:
+      '@wangeditor/core': 1.1.19(@uppy/core@2.3.4)(@uppy/xhr-upload@2.1.3(@uppy/core@2.3.4))(dom7@3.0.0)(is-hotkey@0.2.0)(lodash.camelcase@4.3.0)(lodash.clonedeep@4.5.0)(lodash.debounce@4.0.8)(lodash.foreach@4.5.0)(lodash.isequal@4.5.0)(lodash.throttle@4.1.1)(lodash.toarray@4.4.0)(nanoid@3.3.11)(slate@0.72.8)(snabbdom@3.6.3)
+      dom7: 3.0.0
+      slate: 0.72.8
+      snabbdom: 3.6.3
+
+  '@wangeditor/table-module@1.1.4(@wangeditor/core@1.1.19(@uppy/core@2.3.4)(@uppy/xhr-upload@2.1.3(@uppy/core@2.3.4))(dom7@3.0.0)(is-hotkey@0.2.0)(lodash.camelcase@4.3.0)(lodash.clonedeep@4.5.0)(lodash.debounce@4.0.8)(lodash.foreach@4.5.0)(lodash.isequal@4.5.0)(lodash.throttle@4.1.1)(lodash.toarray@4.4.0)(nanoid@3.3.11)(slate@0.72.8)(snabbdom@3.6.3))(dom7@3.0.0)(lodash.isequal@4.5.0)(lodash.throttle@4.1.1)(nanoid@3.3.11)(slate@0.72.8)(snabbdom@3.6.3)':
+    dependencies:
+      '@wangeditor/core': 1.1.19(@uppy/core@2.3.4)(@uppy/xhr-upload@2.1.3(@uppy/core@2.3.4))(dom7@3.0.0)(is-hotkey@0.2.0)(lodash.camelcase@4.3.0)(lodash.clonedeep@4.5.0)(lodash.debounce@4.0.8)(lodash.foreach@4.5.0)(lodash.isequal@4.5.0)(lodash.throttle@4.1.1)(lodash.toarray@4.4.0)(nanoid@3.3.11)(slate@0.72.8)(snabbdom@3.6.3)
+      dom7: 3.0.0
+      lodash.isequal: 4.5.0
+      lodash.throttle: 4.1.1
+      nanoid: 3.3.11
+      slate: 0.72.8
+      snabbdom: 3.6.3
+
+  '@wangeditor/upload-image-module@1.0.2(@uppy/core@2.3.4)(@uppy/xhr-upload@2.1.3(@uppy/core@2.3.4))(@wangeditor/basic-modules@1.1.7(@wangeditor/core@1.1.19(@uppy/core@2.3.4)(@uppy/xhr-upload@2.1.3(@uppy/core@2.3.4))(dom7@3.0.0)(is-hotkey@0.2.0)(lodash.camelcase@4.3.0)(lodash.clonedeep@4.5.0)(lodash.debounce@4.0.8)(lodash.foreach@4.5.0)(lodash.isequal@4.5.0)(lodash.throttle@4.1.1)(lodash.toarray@4.4.0)(nanoid@3.3.11)(slate@0.72.8)(snabbdom@3.6.3))(dom7@3.0.0)(lodash.throttle@4.1.1)(nanoid@3.3.11)(slate@0.72.8)(snabbdom@3.6.3))(@wangeditor/core@1.1.19(@uppy/core@2.3.4)(@uppy/xhr-upload@2.1.3(@uppy/core@2.3.4))(dom7@3.0.0)(is-hotkey@0.2.0)(lodash.camelcase@4.3.0)(lodash.clonedeep@4.5.0)(lodash.debounce@4.0.8)(lodash.foreach@4.5.0)(lodash.isequal@4.5.0)(lodash.throttle@4.1.1)(lodash.toarray@4.4.0)(nanoid@3.3.11)(slate@0.72.8)(snabbdom@3.6.3))(dom7@3.0.0)(lodash.foreach@4.5.0)(slate@0.72.8)(snabbdom@3.6.3)':
+    dependencies:
+      '@uppy/core': 2.3.4
+      '@uppy/xhr-upload': 2.1.3(@uppy/core@2.3.4)
+      '@wangeditor/basic-modules': 1.1.7(@wangeditor/core@1.1.19(@uppy/core@2.3.4)(@uppy/xhr-upload@2.1.3(@uppy/core@2.3.4))(dom7@3.0.0)(is-hotkey@0.2.0)(lodash.camelcase@4.3.0)(lodash.clonedeep@4.5.0)(lodash.debounce@4.0.8)(lodash.foreach@4.5.0)(lodash.isequal@4.5.0)(lodash.throttle@4.1.1)(lodash.toarray@4.4.0)(nanoid@3.3.11)(slate@0.72.8)(snabbdom@3.6.3))(dom7@3.0.0)(lodash.throttle@4.1.1)(nanoid@3.3.11)(slate@0.72.8)(snabbdom@3.6.3)
+      '@wangeditor/core': 1.1.19(@uppy/core@2.3.4)(@uppy/xhr-upload@2.1.3(@uppy/core@2.3.4))(dom7@3.0.0)(is-hotkey@0.2.0)(lodash.camelcase@4.3.0)(lodash.clonedeep@4.5.0)(lodash.debounce@4.0.8)(lodash.foreach@4.5.0)(lodash.isequal@4.5.0)(lodash.throttle@4.1.1)(lodash.toarray@4.4.0)(nanoid@3.3.11)(slate@0.72.8)(snabbdom@3.6.3)
+      dom7: 3.0.0
+      lodash.foreach: 4.5.0
+      slate: 0.72.8
+      snabbdom: 3.6.3
+
+  '@wangeditor/video-module@1.1.4(@uppy/core@2.3.4)(@uppy/xhr-upload@2.1.3(@uppy/core@2.3.4))(@wangeditor/core@1.1.19(@uppy/core@2.3.4)(@uppy/xhr-upload@2.1.3(@uppy/core@2.3.4))(dom7@3.0.0)(is-hotkey@0.2.0)(lodash.camelcase@4.3.0)(lodash.clonedeep@4.5.0)(lodash.debounce@4.0.8)(lodash.foreach@4.5.0)(lodash.isequal@4.5.0)(lodash.throttle@4.1.1)(lodash.toarray@4.4.0)(nanoid@3.3.11)(slate@0.72.8)(snabbdom@3.6.3))(dom7@3.0.0)(nanoid@3.3.11)(slate@0.72.8)(snabbdom@3.6.3)':
+    dependencies:
+      '@uppy/core': 2.3.4
+      '@uppy/xhr-upload': 2.1.3(@uppy/core@2.3.4)
+      '@wangeditor/core': 1.1.19(@uppy/core@2.3.4)(@uppy/xhr-upload@2.1.3(@uppy/core@2.3.4))(dom7@3.0.0)(is-hotkey@0.2.0)(lodash.camelcase@4.3.0)(lodash.clonedeep@4.5.0)(lodash.debounce@4.0.8)(lodash.foreach@4.5.0)(lodash.isequal@4.5.0)(lodash.throttle@4.1.1)(lodash.toarray@4.4.0)(nanoid@3.3.11)(slate@0.72.8)(snabbdom@3.6.3)
+      dom7: 3.0.0
+      nanoid: 3.3.11
+      slate: 0.72.8
+      snabbdom: 3.6.3
 
   '@webassemblyjs/ast@1.11.1':
     dependencies:
@@ -20609,7 +20934,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.4.3(supports-color@6.1.0)
+      debug: 4.4.3(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -21164,13 +21489,13 @@ snapshots:
 
   axios@0.25.0:
     dependencies:
-      follow-redirects: 1.15.11(debug@4.4.3)
+      follow-redirects: 1.15.11(debug@4.4.3(supports-color@6.1.0))
     transitivePeerDependencies:
       - debug
 
   axios@1.12.2:
     dependencies:
-      follow-redirects: 1.15.11(debug@4.4.3)
+      follow-redirects: 1.15.11(debug@4.4.3(supports-color@6.1.0))
       form-data: 4.0.4
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -23192,6 +23517,10 @@ snapshots:
       domhandler: 4.3.1
       entities: 2.2.0
 
+  dom7@3.0.0:
+    dependencies:
+      ssr-window: 3.0.0
+
   domain-browser@1.2.0: {}
 
   domelementtype@1.3.1: {}
@@ -24298,7 +24627,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 2.4.2
       cross-spawn: 6.0.6
-      debug: 4.4.3(supports-color@6.1.0)
+      debug: 4.4.3(supports-color@9.4.0)
       doctrine: 3.0.0
       eslint-scope: 5.1.1
       eslint-utils: 1.4.3
@@ -24341,7 +24670,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@6.1.0)
+      debug: 4.4.3(supports-color@9.4.0)
       doctrine: 3.0.0
       enquirer: 2.4.1
       eslint-scope: 5.1.1
@@ -24384,7 +24713,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@6.1.0)
+      debug: 4.4.3(supports-color@9.4.0)
       doctrine: 3.0.0
       enquirer: 2.4.1
       escape-string-regexp: 4.0.0
@@ -24434,7 +24763,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@6.1.0)
+      debug: 4.4.3(supports-color@9.4.0)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -24923,7 +25252,7 @@ snapshots:
 
   follow-redirects@1.15.11(debug@4.4.3):
     optionalDependencies:
-      debug: 4.4.3(supports-color@6.1.0)
+      debug: 4.4.3(supports-color@9.4.0)
 
   for-each@0.3.5:
     dependencies:
@@ -25568,6 +25897,8 @@ snapshots:
 
   html-tags@2.0.0: {}
 
+  html-void-elements@2.0.1: {}
+
   html-webpack-plugin@3.2.0(webpack@4.44.2):
     dependencies:
       html-minifier: 3.5.21
@@ -25663,7 +25994,7 @@ snapshots:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@6.1.0)
+      debug: 4.4.3(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -25700,7 +26031,7 @@ snapshots:
   http-proxy-middleware@2.0.9(@types/express@4.17.23):
     dependencies:
       '@types/http-proxy': 1.17.16
-      http-proxy: 1.18.1(debug@4.4.3)
+      http-proxy: 1.18.1(debug@4.4.3(supports-color@6.1.0))
       is-glob: 4.0.3
       is-plain-obj: 3.0.0
       micromatch: 4.0.8
@@ -25736,7 +26067,7 @@ snapshots:
   https-proxy-agent@5.0.0:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@6.1.0)
+      debug: 4.4.3(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -25758,6 +26089,10 @@ snapshots:
       ms: 2.1.3
 
   husky@7.0.4: {}
+
+  i18next@20.6.1:
+    dependencies:
+      '@babel/runtime': 7.28.4
 
   iconv-lite@0.4.24:
     dependencies:
@@ -26084,6 +26419,8 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-hotkey@0.2.0: {}
+
   is-interactive@1.0.0: {}
 
   is-lambda@1.0.1: {}
@@ -26193,6 +26530,8 @@ snapshots:
 
   is-unicode-supported@0.1.0: {}
 
+  is-url@1.2.4: {}
+
   is-weakmap@2.0.2: {}
 
   is-weakref@1.1.1:
@@ -26265,7 +26604,7 @@ snapshots:
 
   istanbul-lib-source-maps@4.0.1:
     dependencies:
-      debug: 4.4.3(supports-color@6.1.0)
+      debug: 4.4.3(supports-color@9.4.0)
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -26941,7 +27280,7 @@ snapshots:
       dom-serialize: 2.2.1
       glob: 7.2.3
       graceful-fs: 4.2.11
-      http-proxy: 1.18.1(debug@4.4.3)
+      http-proxy: 1.18.1(debug@4.4.3(supports-color@6.1.0))
       isbinaryfile: 4.0.10
       lodash: 4.17.21
       log4js: 6.9.1
@@ -27193,9 +27532,17 @@ snapshots:
 
   lodash._reinterpolate@3.0.0: {}
 
+  lodash.camelcase@4.3.0: {}
+
+  lodash.clonedeep@4.5.0: {}
+
   lodash.debounce@4.0.8: {}
 
   lodash.defaultsdeep@4.6.1: {}
+
+  lodash.foreach@4.5.0: {}
+
+  lodash.isequal@4.5.0: {}
 
   lodash.ismatch@4.4.0: {}
 
@@ -27217,6 +27564,10 @@ snapshots:
   lodash.templatesettings@4.2.0:
     dependencies:
       lodash._reinterpolate: 3.0.0
+
+  lodash.throttle@4.1.1: {}
+
+  lodash.toarray@4.4.0: {}
 
   lodash.transform@4.6.0: {}
 
@@ -27245,7 +27596,7 @@ snapshots:
   log4js@6.9.1:
     dependencies:
       date-format: 4.0.14
-      debug: 4.4.3(supports-color@6.1.0)
+      debug: 4.4.3(supports-color@9.4.0)
       flatted: 3.3.3
       rfdc: 1.4.1
       streamroller: 3.1.5
@@ -27507,6 +27858,10 @@ snapshots:
 
   mime-db@1.54.0: {}
 
+  mime-match@1.0.2:
+    dependencies:
+      wildcard: 1.1.2
+
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
@@ -27727,6 +28082,8 @@ snapshots:
       any-promise: 1.3.0
       object-assign: 4.1.1
       thenify-all: 1.6.0
+
+  namespace-emitter@2.0.1: {}
 
   nan@2.23.0:
     optional: true
@@ -28579,6 +28936,13 @@ snapshots:
       - typescript
 
   popper.js@1.16.1: {}
+
+  portfinder@1.0.38:
+    dependencies:
+      async: 3.2.6
+      debug: 4.4.3(supports-color@9.4.0)
+    transitivePeerDependencies:
+      - supports-color
 
   portfinder@1.0.38(supports-color@6.1.0):
     dependencies:
@@ -29507,6 +29871,8 @@ snapshots:
       ansi-regex: 5.0.1
       ansi-styles: 5.2.0
       react-is: 18.3.1
+
+  prismjs@1.30.0: {}
 
   proc-log@3.0.0: {}
 
@@ -31563,6 +31929,17 @@ snapshots:
 
   slash@4.0.0: {}
 
+  slate-history@0.66.0(slate@0.72.8):
+    dependencies:
+      is-plain-object: 5.0.0
+      slate: 0.72.8
+
+  slate@0.72.8:
+    dependencies:
+      immer: 9.0.21
+      is-plain-object: 5.0.0
+      tiny-warning: 1.0.3
+
   slice-ansi@2.1.0:
     dependencies:
       ansi-styles: 3.2.1
@@ -31587,6 +31964,8 @@ snapshots:
       is-fullwidth-code-point: 4.0.0
 
   smart-buffer@4.2.0: {}
+
+  snabbdom@3.6.3: {}
 
   snapdragon-node@2.1.1:
     dependencies:
@@ -31660,7 +32039,7 @@ snapshots:
   socks-proxy-agent@6.2.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@6.1.0)
+      debug: 4.4.3(supports-color@9.4.0)
       socks: 2.8.7
     transitivePeerDependencies:
       - supports-color
@@ -31668,7 +32047,7 @@ snapshots:
   socks-proxy-agent@7.0.0:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@6.1.0)
+      debug: 4.4.3(supports-color@9.4.0)
       socks: 2.8.7
     transitivePeerDependencies:
       - supports-color
@@ -31764,6 +32143,17 @@ snapshots:
 
   spdx-license-ids@3.0.22: {}
 
+  spdy-transport@3.0.0:
+    dependencies:
+      debug: 4.4.3(supports-color@9.4.0)
+      detect-node: 2.1.0
+      hpack.js: 2.1.6
+      obuf: 1.1.2
+      readable-stream: 3.6.2
+      wbuf: 1.7.3
+    transitivePeerDependencies:
+      - supports-color
+
   spdy-transport@3.0.0(supports-color@6.1.0):
     dependencies:
       debug: 4.4.3(supports-color@6.1.0)
@@ -31772,6 +32162,16 @@ snapshots:
       obuf: 1.1.2
       readable-stream: 3.6.2
       wbuf: 1.7.3
+    transitivePeerDependencies:
+      - supports-color
+
+  spdy@4.0.2:
+    dependencies:
+      debug: 4.4.3(supports-color@9.4.0)
+      handle-thing: 2.0.1
+      http-deceiver: 1.2.7
+      select-hose: 2.0.0
+      spdy-transport: 3.0.0
     transitivePeerDependencies:
       - supports-color
 
@@ -31816,6 +32216,8 @@ snapshots:
       jsbn: 0.1.1
       safer-buffer: 2.1.2
       tweetnacl: 0.14.5
+
+  ssr-window@3.0.0: {}
 
   ssri@10.0.6:
     dependencies:
@@ -31882,7 +32284,7 @@ snapshots:
   streamroller@3.1.5:
     dependencies:
       date-format: 4.0.14
-      debug: 4.4.3(supports-color@6.1.0)
+      debug: 4.4.3(supports-color@9.4.0)
       fs-extra: 8.1.0
     transitivePeerDependencies:
       - supports-color
@@ -32389,6 +32791,8 @@ snapshots:
 
   tinycolor2@1.6.0: {}
 
+  tinymce@6.8.6: {}
+
   tmp@0.0.33:
     dependencies:
       os-tmpdir: 1.0.2
@@ -32527,7 +32931,7 @@ snapshots:
   tuf-js@1.1.7:
     dependencies:
       '@tufjs/models': 1.0.4
-      debug: 4.4.3(supports-color@6.1.0)
+      debug: 4.4.3(supports-color@9.4.0)
       make-fetch-happen: 11.1.1
     transitivePeerDependencies:
       - supports-color
@@ -33007,7 +33411,7 @@ snapshots:
 
   vue-eslint-parser@7.11.0(eslint@6.8.0):
     dependencies:
-      debug: 4.4.3(supports-color@6.1.0)
+      debug: 4.4.3(supports-color@9.4.0)
       eslint: 6.8.0
       eslint-scope: 5.1.1
       eslint-visitor-keys: 1.3.0
@@ -33020,7 +33424,7 @@ snapshots:
 
   vue-eslint-parser@7.11.0(eslint@7.12.0):
     dependencies:
-      debug: 4.4.3(supports-color@6.1.0)
+      debug: 4.4.3(supports-color@9.4.0)
       eslint: 7.12.0
       eslint-scope: 5.1.1
       eslint-visitor-keys: 1.3.0
@@ -33033,7 +33437,7 @@ snapshots:
 
   vue-eslint-parser@8.3.0(eslint@8.57.1):
     dependencies:
-      debug: 4.4.3(supports-color@6.1.0)
+      debug: 4.4.3(supports-color@9.4.0)
       eslint: 8.57.1
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3
@@ -33462,7 +33866,7 @@ snapshots:
       selfsigned: 2.4.1
       serve-index: 1.9.1(supports-color@6.1.0)
       sockjs: 0.3.24
-      spdy: 4.0.2(supports-color@6.1.0)
+      spdy: 4.0.2
       webpack-dev-middleware: 5.3.4(webpack@5.98.0)
       ws: 8.18.3
     optionalDependencies:
@@ -33708,6 +34112,8 @@ snapshots:
   wide-align@1.1.5:
     dependencies:
       string-width: 4.2.3
+
+  wildcard@1.1.2: {}
 
   wildcard@2.0.1: {}
 


### PR DESCRIPTION
## Summary

修复无界环境下 wangEditor / Slate / TinyMCE 等富文本编辑器常见的跨 realm 与降级（`degrade`）双 iframe 问题，并增加可回归的示例与单元测试。

**框架（wujie-core）**
- `patchInstanceofAcrossRealms`：子应用 DOM 构造函数认可主应用 realm 对象；补充 `DataTransfer` / `ClipboardEvent`；修复继承链导致 patch 跳过；双向 patch 使用原生 `Symbol.hasInstance` 避免递归
- **降级模式**：`getSelection` 指向 `sandbox.document`；节点 `ownerDocument` 指向渲染 iframe；`patchDegradeInstanceofAcrossRealms` 在执行/渲染 iframe 间双向 patch
- `deferStyleSheetByHref`：延迟注入带 `href` 的 `<link rel="stylesheet">`（TinyMCE skin 等）；`unmount`/`destroy` 时清理 `MutationObserver`
- 集成测试前释放占用端口的脚本；instanceof 集成/单元测试

**示例**
- vue2 子应用 `/rich-text`：wangEditor（#513 快速输入、#479 粘贴、#450/#770 选区、isCollapsed）与 TinyMCE
- main-vue `wangEditorPlugin`：`Selection` / `DataTransfer` 跨 realm（含降级）

**文档**
- `notes/rich-text-editors-issues.md`：社区 issue 调研索引

Fixes #513
Fixes #450
Fixes #770
Fixes #224

相关：#479、#489、#974（#224 重复）

## Test plan

- [x] `cd packages/wujie-core && pnpm test:unit`
- [ ] `pnpm run lib` 后启动 main-vue + vue2，访问 `/vue2-sub/rich-text`
- [ ] 非降级：wangEditor 快速输入、粘贴、选区
- [ ] 降级模式：#513 快速输入不失焦
- [ ] TinyMCE 皮肤正常（vue2 需 `pnpm install` 触发 `copy-tinymce.js`）



<!--
感谢您贡献代码，共建指引详见: https://github.com/Tencent/wujie/blob/master/CONTRIBUTING.md

##### Checklist

<!-- 如已完成将 [ ] 改成 [x]，可以删除不涉及的条目 -->

- [x] 提交符合commit规范
- [x] 文档更改
- [x] 测试用例添加
- [x] `npm run test`通过

##### 详细描述

- 特性
- 关联issue
