### PR TITLE
fix(core): 修复跨 realm 的 DOM instanceof 判断

### DIFF
--- a/packages/wujie-core/__test__/integration/instanceof.test.ts
+++ b/packages/wujie-core/__test__/integration/instanceof.test.ts
@@ -1,0 +1,46 @@
+import { vueMainAppInfoMap } from "./common";
+import { awaitConsoleLogMessage } from "./utils";
+
+describe("main vue instanceof patch", () => {
+  beforeAll(async () => {
+    await page.evaluateOnNewDocument(() => {
+      localStorage.clear();
+      localStorage.setItem("preload", "false");
+      localStorage.setItem("degrade", "false");
+    });
+    await page.goto("http://localhost:8000/");
+  });
+
+  it("example 子应用中主应用 realm 的元素和事件应通过子应用构造函数的 instanceof 判断", async () => {
+    const appInfo = vueMainAppInfoMap.vue3;
+    const appInfoMountedPromise = awaitConsoleLogMessage(page, appInfo.mountedMessage);
+    await page.click(appInfo.linkSelector);
+    await appInfoMountedPromise;
+
+    const result = await page.evaluate((childName) => {
+      const childWindow = (window.frames as any)[childName];
+      const childProxyWindow = childWindow.__WUJIE.proxy;
+      const mainElement = document.createElement("div");
+      const mainMouseEvent = new MouseEvent("click");
+      const childElement = childWindow.document.createElement("div");
+
+      return {
+        mainElementIsChildDiv: mainElement instanceof childProxyWindow.HTMLDivElement,
+        mainElementIsChildHTMLElement: mainElement instanceof childProxyWindow.HTMLElement,
+        mainEventIsChildMouseEvent: mainMouseEvent instanceof childProxyWindow.MouseEvent,
+        mainEventIsChildEvent: mainMouseEvent instanceof childProxyWindow.Event,
+        childElementStillWorks: childElement instanceof childProxyWindow.HTMLDivElement,
+        hasPatchMark: childProxyWindow.HTMLDivElement._hasPatch === true,
+      };
+    }, appInfo.name);
+
+    expect(result).toEqual({
+      mainElementIsChildDiv: true,
+      mainElementIsChildHTMLElement: true,
+      mainEventIsChildMouseEvent: true,
+      mainEventIsChildEvent: true,
+      childElementStillWorks: true,
+      hasPatchMark: true,
+    });
+  });
+});

--- a/packages/wujie-core/__test__/unit/instanceof-patch.test.ts
+++ b/packages/wujie-core/__test__/unit/instanceof-patch.test.ts
@@ -1,0 +1,60 @@
+export {};
+
+import * as iframeModule from "../../src/iframe";
+
+function createIframeWindow() {
+  const iframe = document.createElement("iframe");
+  document.body.appendChild(iframe);
+  return iframe.contentWindow as any;
+}
+
+describe("patchInstanceofAcrossRealms", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  test("让主应用 realm 的元素和事件通过子应用构造函数的 instanceof 判断", () => {
+    const iframeWindow = createIframeWindow();
+    const patchInstanceofAcrossRealms = (iframeModule as any).patchInstanceofAcrossRealms;
+
+    expect(typeof patchInstanceofAcrossRealms).toBe("function");
+
+    const mainElement = document.createElement("div");
+    const mainMouseEvent = new MouseEvent("click");
+
+    expect(mainElement instanceof iframeWindow.HTMLDivElement).toBe(false);
+    expect(mainMouseEvent instanceof iframeWindow.MouseEvent).toBe(false);
+
+    patchInstanceofAcrossRealms(iframeWindow);
+
+    expect(mainElement instanceof iframeWindow.HTMLDivElement).toBe(true);
+    expect(mainElement instanceof iframeWindow.HTMLElement).toBe(true);
+    expect(mainMouseEvent instanceof iframeWindow.MouseEvent).toBe(true);
+    expect(mainMouseEvent instanceof iframeWindow.Event).toBe(true);
+  });
+
+  test("保留子应用 realm 原有 instanceof 判断", () => {
+    const iframeWindow = createIframeWindow();
+    const patchInstanceofAcrossRealms = (iframeModule as any).patchInstanceofAcrossRealms;
+    const childElement = iframeWindow.document.createElement("div");
+    const childMouseEvent = new iframeWindow.MouseEvent("click");
+
+    patchInstanceofAcrossRealms(iframeWindow);
+
+    expect(childElement instanceof iframeWindow.HTMLDivElement).toBe(true);
+    expect(childMouseEvent instanceof iframeWindow.MouseEvent).toBe(true);
+  });
+
+  test("重复 patch 时应保持幂等，避免 hasInstance 闭包堆叠", () => {
+    const iframeWindow = createIframeWindow();
+    const patchInstanceofAcrossRealms = (iframeModule as any).patchInstanceofAcrossRealms;
+
+    patchInstanceofAcrossRealms(iframeWindow);
+    const patchedHasInstance = iframeWindow.HTMLDivElement[Symbol.hasInstance];
+
+    patchInstanceofAcrossRealms(iframeWindow);
+
+    expect((iframeWindow.HTMLDivElement as any)._hasPatch).toBe(true);
+    expect(iframeWindow.HTMLDivElement[Symbol.hasInstance]).toBe(patchedHasInstance);
+  });
+});

--- a/packages/wujie-core/jest-puppeteer.config.js
+++ b/packages/wujie-core/jest-puppeteer.config.js
@@ -5,10 +5,12 @@ const LERNA_EXEC = resolve(__dirname, "../../node_modules/.bin/lerna");
 // 本地开发不设置该变量时保持默认行为
 const launchArgs = (process.env.PUPPETEER_LAUNCH_ARGS || "").split(/\s+/).filter(Boolean);
 
+const isDebug = false;
+
 module.exports = {
   launch: {
-    headless: true,
-    devtools: false,
+    headless: !isDebug,
+    devtools: isDebug,
     product: "chrome",
     ...(launchArgs.length ? { args: launchArgs } : {}),
   },

--- a/packages/wujie-core/package.json
+++ b/packages/wujie-core/package.json
@@ -17,7 +17,8 @@
     "lint": "eslint --ext .ts ./src  --fix",
     "test": "npm run test:unit && NODE_OPTIONS=--openssl-legacy-provider npm run test:integration",
     "test:unit": "jest -c __test__/unit/jest.config.js",
-    "test:integration": "jest -c __test__/integration/jest.config.js --runInBand"
+    "kill-integration-ports": "node scripts/kill-integration-ports.js",
+    "test:integration": "npm run kill-integration-ports && NODE_OPTIONS=--openssl-legacy-provider jest -c __test__/integration/jest.config.js --runInBand"
   },
   "repository": {
     "type": "git",

--- a/packages/wujie-core/scripts/kill-integration-ports.js
+++ b/packages/wujie-core/scripts/kill-integration-ports.js
@@ -1,0 +1,87 @@
+/**
+ * 集成测试启动前释放 jest-puppeteer.config.js 里占用的端口。
+ * jest-dev-server 的 usedPortAction: "kill" 依赖 find-process，在 macOS 上常查不到监听进程会报错。
+ */
+const { execSync } = require("child_process");
+
+/** 与 jest-puppeteer.config.js 中 server[].port 保持一致 */
+const INTEGRATION_PORTS = [7600, 7100, 7200, 7300, 7500, 7400, 7700, 8000];
+
+function execQuiet(command) {
+  return execSync(command, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  }).trim();
+}
+
+/** @returns {string[]} */
+function getListenerPidsOnPort(port) {
+  const platform = process.platform;
+
+  if (platform === "win32") {
+    try {
+      const stdout = execQuiet(`netstat -ano | findstr :${port}`);
+      const pids = stdout
+        .split("\n")
+        .map((line) => line.trim().split(/\s+/))
+        .filter((parts) => parts.length >= 5 && parts[3] === "LISTENING")
+        .map((parts) => parts[parts.length - 1]);
+      return [...new Set(pids.filter(Boolean))];
+    } catch {
+      return [];
+    }
+  }
+
+  // macOS / Linux / 其他类 Unix：优先 lsof
+  try {
+    const stdout = execQuiet(`lsof -nP -iTCP:${port} -sTCP:LISTEN -t`);
+    return [...new Set(stdout.split("\n").filter(Boolean))];
+  } catch {
+    /* lsof 未安装或 -s 语法不支持时走 Linux 常见兜底 */
+  }
+
+  if (platform === "linux") {
+    try {
+      // fuser 在多数 Linux 发行版默认可用
+      const stdout = execQuiet(`fuser -n tcp ${port} 2>/dev/null`);
+      return [...new Set(stdout.split(/\s+/).filter(Boolean))];
+    } catch {
+      /* ignore */
+    }
+
+    try {
+      // ss 常见于 util-linux，输出形如 users:(("node",pid=12345,fd=20))
+      const stdout = execQuiet(`ss -H -ltnp sport = :${port}`);
+      const pids = [...stdout.matchAll(/pid=(\d+)/g)].map((m) => m[1]);
+      return [...new Set(pids)];
+    } catch {
+      return [];
+    }
+  }
+
+  return [];
+}
+
+function killListenersOnPort(port) {
+  const pids = getListenerPidsOnPort(port);
+  pids.forEach((pid) => {
+    try {
+      process.kill(Number(pid), "SIGTERM");
+      console.log(`[kill-integration-ports] SIGTERM pid=${pid} port=${port}`);
+    } catch (error) {
+      if (error.code !== "ESRCH") {
+        console.warn(`[kill-integration-ports] failed pid=${pid} port=${port}:`, error.message);
+      }
+    }
+  });
+}
+
+function delay(ms) {
+  const end = Date.now() + ms;
+  while (Date.now() < end) {
+    /* 跨平台等待端口释放，避免依赖 shell 的 sleep */
+  }
+}
+
+INTEGRATION_PORTS.forEach(killListenersOnPort);
+delay(500);

--- a/packages/wujie-core/src/iframe.ts
+++ b/packages/wujie-core/src/iframe.ts
@@ -38,6 +38,33 @@ import { getJsLoader } from "./plugin";
 import { WUJIE_TIPS_SCRIPT_ERROR_REQUESTED, WUJIE_DATA_FLAG } from "./constant";
 import { ScriptObjectLoader } from "./index";
 
+const extraInstanceofConstructorNames = new Set([
+  "CSSStyleDeclaration",
+  "DOMImplementation",
+  "DOMMatrix",
+  "DOMMatrixReadOnly",
+  "DOMParser",
+  "DOMPoint",
+  "DOMPointReadOnly",
+  "DOMQuad",
+  "DOMRect",
+  "DOMRectList",
+  "DOMRectReadOnly",
+  "DOMStringList",
+  "DOMStringMap",
+  "DOMTokenList",
+  "HTMLCollection",
+  "MediaList",
+  "NamedNodeMap",
+  "Range",
+  "Selection",
+  "StyleSheet",
+  "StyleSheetList",
+  "TextDecoder",
+  "TextEncoder",
+  "TimeRanges",
+]);
+
 declare global {
   interface Window {
     // 是否存在无界
@@ -290,8 +317,60 @@ export function patchWindowEffect(iframeWindow: Window): void {
       warn(e.message);
     }
   });
+  if (!iframeWindow.__WUJIE.degrade) patchInstanceofAcrossRealms(iframeWindow);
   // 运行插件钩子函数
   execHooks(iframeWindow.__WUJIE.plugins, "windowPropertyOverride", iframeWindow);
+}
+
+function isDomConstructor(name: string, ctor: Function, mainWindow: Window): boolean {
+  const prototype = ctor.prototype;
+  if (!prototype) return false;
+  if (ctor === mainWindow.EventTarget || ctor === mainWindow.Event) return true;
+  if (prototype instanceof mainWindow.EventTarget || prototype instanceof mainWindow.Event) return true;
+  if (/^(HTML|SVG|MathML).+Element$/.test(name)) return true;
+  return extraInstanceofConstructorNames.has(name);
+}
+
+/**
+ * 修复非降级模式下，主应用 realm 的 DOM 对象无法通过子应用 realm 构造函数 instanceof 的问题。
+ */
+export function patchInstanceofAcrossRealms(iframeWindow: Window): void {
+  // DOM 构造函数之间存在继承链（HTMLIFrameElement -> HTMLElement -> Element -> Node ...），
+  // 对构造函数的属性读取会沿这条链向上查找。因此 _hasPatch / Symbol.hasInstance 必须用 own
+  // 语义判断，否则会读到已被 patch 的祖先构造函数的值，导致 patch 被跳过或判断串味到祖先 realm。
+  const nativeHasInstance = Function.prototype[Symbol.hasInstance];
+  Object.getOwnPropertyNames(iframeWindow).forEach((name) => {
+    let appConstructor: Function & { _hasPatch?: boolean };
+    let mainConstructor: Function;
+
+    try {
+      appConstructor = iframeWindow[name];
+      mainConstructor = window[name];
+    } catch (error) {
+      return;
+    }
+
+    if (typeof appConstructor !== "function" || typeof mainConstructor !== "function") return;
+    if (appConstructor === mainConstructor || Object.prototype.hasOwnProperty.call(appConstructor, "_hasPatch")) return;
+    if (!isDomConstructor(name, mainConstructor, window)) return;
+
+    try {
+      Object.defineProperties(appConstructor, {
+        [Symbol.hasInstance]: {
+          configurable: true,
+          value(element: unknown) {
+            // 用 this 而非闭包变量，确保命中的始终是当前构造函数自己的判断，
+            // 用原生 hasInstance 避免沿构造函数继承链拿到被 patch 的祖先实现。
+            if (nativeHasInstance.call(this, element)) return true;
+            return element instanceof mainConstructor;
+          },
+        },
+        _hasPatch: { value: true },
+      });
+    } catch (error) {
+      console.warn(error);
+    }
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary

为非降级模式 patch 子应用 realm 的 DOM 构造函数 `Symbol.hasInstance`，使主应用 realm 的元素/事件能通过子应用构造函数的 `instanceof` 判断；修复构造函数继承链导致 patch 被跳过的问题。

## 变更（commit `2c5b3cd`）

- `packages/wujie-core/src/iframe.ts`：`patchInstanceofAcrossRealms`
- 单元 / 集成测试
- `kill-integration-ports.js`

Fixes #510
Fixes #930

## Test plan

- [ ] `cd packages/wujie-core && pnpm test:unit`
- [ ] `pnpm run lib` 后 `pnpm run test:integration`