### PR TITLE
fix(wujie-core): 降级渲染 iframe 注入 base 修复静态资源路径

### DIFF
--- a/packages/wujie-core/__test__/unit/init-base.test.ts
+++ b/packages/wujie-core/__test__/unit/init-base.test.ts
@@ -1,0 +1,48 @@
+import { initBase } from "../../src/iframe";
+
+describe("initBase", () => {
+  it("uses iframe location pathname by default", () => {
+    const iframe = document.createElement("iframe");
+    document.body.appendChild(iframe);
+    const win = iframe.contentWindow as Window;
+    win.document.open();
+    win.document.write("<!DOCTYPE html><html><head></head><body></body></html>");
+    win.document.close();
+
+    initBase(win, "http://localhost:7600/app/");
+
+    const base = win.document.head.querySelector("base");
+    expect(base?.getAttribute("href")).toBe(`http://localhost:7600${win.location.pathname}`);
+    document.body.removeChild(iframe);
+  });
+
+  it("uses explicit pathname for degrade render iframe", () => {
+    const iframe = document.createElement("iframe");
+    document.body.appendChild(iframe);
+    const win = iframe.contentWindow as Window;
+    win.document.open();
+    win.document.write("<!DOCTYPE html><html><head></head><body></body></html>");
+    win.document.close();
+
+    initBase(win, "http://localhost:7600/", "/react16-sub/home");
+
+    const base = win.document.head.querySelector("base");
+    expect(base?.getAttribute("href")).toBe("http://localhost:7600/react16-sub/home");
+    document.body.removeChild(iframe);
+  });
+
+  it("skips when head already has base", () => {
+    const iframe = document.createElement("iframe");
+    document.body.appendChild(iframe);
+    const win = iframe.contentWindow as Window;
+    win.document.open();
+    win.document.write('<!DOCTYPE html><html><head><base href="http://existing/"></head><body></body></html>');
+    win.document.close();
+
+    initBase(win, "http://localhost:7600/", "/ignored");
+
+    expect(win.document.head.querySelectorAll("base")).toHaveLength(1);
+    expect(win.document.head.querySelector("base")?.getAttribute("href")).toBe("http://existing/");
+    document.body.removeChild(iframe);
+  });
+});

--- a/packages/wujie-core/src/iframe.ts
+++ b/packages/wujie-core/src/iframe.ts
@@ -761,15 +761,18 @@ function patchRelativeUrlEffect(iframeWindow: Window): void {
 }
 
 /**
- * 初始化base标签
+ * 初始化 base 标签，供 document 内相对路径资源解析使用。
+ * @param pathname 可选；降级渲染 iframe 的 location 为 about:blank，需传入 proxyLocation.pathname
  */
-export function initBase(iframeWindow: Window, url: string): void {
+export function initBase(iframeWindow: Window, url: string, pathname?: string): void {
   const iframeDocument = iframeWindow.document;
+  if (!iframeDocument.head || iframeDocument.head.querySelector("base")) return;
   const baseElement = iframeDocument.createElement("base");
   const iframeUrlElement = anchorElementGenerator(iframeWindow.location.href);
   const appUrlElement = anchorElementGenerator(url);
-  baseElement.setAttribute("href", appUrlElement.protocol + "//" + appUrlElement.host + iframeUrlElement.pathname);
-  iframeDocument.head.appendChild(baseElement);
+  const resolvedPathname = pathname ?? iframeUrlElement.pathname;
+  baseElement.setAttribute("href", appUrlElement.protocol + "//" + appUrlElement.host + resolvedPathname);
+  iframeDocument.head.insertBefore(baseElement, iframeDocument.head.firstChild);
 }
 
 /**

--- a/packages/wujie-core/src/shadow.ts
+++ b/packages/wujie-core/src/shadow.ts
@@ -17,7 +17,7 @@ import {
 } from "./common";
 import { getExternalStyleSheets } from "./entry";
 import Wujie from "./sandbox";
-import { patchElementEffect } from "./iframe";
+import { initBase, patchElementEffect } from "./iframe";
 import { patchRenderEffect } from "./effect";
 import { getCssLoader, getPresetLoaders } from "./plugin";
 import { getAbsolutePath, getContainer, getCurUrl, isFunction, setAttrsToElement } from "./utils";
@@ -307,6 +307,13 @@ export async function renderTemplateToIframe(
     configurable: true,
     get: () => iframeWindow.document,
   });
+
+  // 降级渲染 iframe 无 src 补丁，需与 JS iframe 一样注入 base，供 img 等相对路径解析到子应用域名
+  const renderWindow = renderDocument.defaultView;
+  const proxyLocation = iframeWindow.__WUJIE.proxyLocation as Location;
+  if (renderWindow) {
+    initBase(renderWindow, iframeWindow.__WUJIE.url, proxyLocation.pathname);
+  }
 
   patchRenderEffect(renderDocument, iframeWindow.__WUJIE.id, true);
 }


### PR DESCRIPTION
## Summary

- 降级模式下可见 DOM 在渲染 iframe，节点 adopt 后不再走 JS iframe 上 `fixElementCtrSrcOrHref` 的 prototype 补丁，webpack 静态资源（如 react16 logo）会解析到主应用域名
- 在 `renderTemplateToIframe` 注入与 JS iframe 一致的 `<base>` 标签，使 `/static/...` 等资源正确解析到子应用 host
- 扩展 `initBase`：支持传入 `proxyLocation.pathname`（渲染 iframe 为 `about:blank`），已有 `<base>` 时跳过，插入到 `<head>` 最前

## Test plan

- [x] `pnpm test:unit -- init-base.test.ts` 通过（3 个用例）
- [x] 主应用开启降级模式，进入 react16 子应用
- [x] 控制台执行 `document.querySelector("iframe[data-wujie-id='react16']").contentDocument.querySelector(".App-logo").src`，应指向 `http://localhost:7600/static/media/...`
- [x] logo 图片正常显示
