### PR TITLE
fix(adapter): 清理 __WUJIE_QUEUE 防止组件销毁后内存泄漏

### DIFF
--- a/packages/wujie-react/index.js
+++ b/packages/wujie-react/index.js
@@ -2,6 +2,18 @@ import React from "react";
 import PropTypes from "prop-types";
 import { bus, preloadApp, startApp, destroyApp, setupApp } from "wujie";
 
+/**
+ * 清理全局 startApp 串行队列，防止组件销毁后 window.__WUJIE_QUEUE 长期持有
+ * 已卸载实例的 Promise 链，造成内存泄漏。
+ * 仅当全局队列仍指向当前实例的链尾时才删除，避免误删被同名新实例接管的队列。
+ */
+function clearStartAppQueue(name, queue) {
+  if (!name || !window.__WUJIE_QUEUE) return;
+  if (window.__WUJIE_QUEUE[name] === queue) {
+    delete window.__WUJIE_QUEUE[name];
+  }
+}
+
 export default class WujieReact extends React.PureComponent {
   static propTypes = propTypes;
   static bus = bus;
@@ -32,7 +44,9 @@ export default class WujieReact extends React.PureComponent {
 
   execStartApp = () => {
     this.startAppQueue = this.startAppQueue.then(this.startApp);
-    window.__WUJIE_QUEUE[this.name] = this.startAppQueue;
+    if (this.props.name && window.__WUJIE_QUEUE) {
+      window.__WUJIE_QUEUE[this.props.name] = this.startAppQueue;
+    }
   };
 
   componentDidMount() {
@@ -56,6 +70,10 @@ export default class WujieReact extends React.PureComponent {
     if (this.props.name !== prevProps.name || this.props.url !== prevProps.url) {
       this.execStartApp();
     }
+  }
+
+  componentWillUnmount() {
+    clearStartAppQueue(this.props.name, this.startAppQueue);
   }
 
   render() {

--- a/packages/wujie-vue2/index.js
+++ b/packages/wujie-vue2/index.js
@@ -1,6 +1,18 @@
 import Vue from "vue";
 import { bus, preloadApp, startApp as rawStartApp, destroyApp, setupApp } from "wujie";
 
+/**
+ * 清理全局 startApp 串行队列，防止组件销毁后 window.__WUJIE_QUEUE 长期持有
+ * 已卸载实例的 Promise 链，造成内存泄漏。
+ * 仅当全局队列仍指向当前实例的链尾时才删除，避免误删被同名新实例接管的队列。
+ */
+function clearStartAppQueue(name, queue) {
+  if (!name || !window.__WUJIE_QUEUE) return;
+  if (window.__WUJIE_QUEUE[name] === queue) {
+    delete window.__WUJIE_QUEUE[name];
+  }
+}
+
 const wujieVueOptions = {
   name: "WujieVue",
   props: {
@@ -96,7 +108,9 @@ const wujieVueOptions = {
     },
     execStartApp() {
       this.startAppQueue = this.startAppQueue.then(this.startApp);
-      window.__WUJIE_QUEUE[this.name] = this.startAppQueue;
+      if (this.name && window.__WUJIE_QUEUE) {
+        window.__WUJIE_QUEUE[this.name] = this.startAppQueue;
+      }
     },
     destroy() {
       destroyApp(this.name);
@@ -104,6 +118,7 @@ const wujieVueOptions = {
   },
   beforeDestroy() {
     bus.$offAll(this.handleEmit);
+    clearStartAppQueue(this.name, this.startAppQueue);
   },
   render(c) {
     return c("div", {

--- a/packages/wujie-vue3/index.js
+++ b/packages/wujie-vue3/index.js
@@ -1,6 +1,18 @@
 import { bus, preloadApp, startApp as rawStartApp, destroyApp, setupApp } from "wujie";
 import { h, defineComponent } from "vue";
 
+/**
+ * 清理全局 startApp 串行队列，防止组件销毁后 window.__WUJIE_QUEUE 长期持有
+ * 已卸载实例的 Promise 链，造成内存泄漏。
+ * 仅当全局队列仍指向当前实例的链尾时才删除，避免误删被同名新实例接管的队列。
+ */
+function clearStartAppQueue(name, queue) {
+  if (!name || !window.__WUJIE_QUEUE) return;
+  if (window.__WUJIE_QUEUE[name] === queue) {
+    delete window.__WUJIE_QUEUE[name];
+  }
+}
+
 const wujieVueOptions = {
   name: "WujieVue",
   props: {
@@ -95,7 +107,9 @@ const wujieVueOptions = {
     },
     execStartApp() {
       this.startAppQueue = this.startAppQueue.then(this.startApp);
-      window.__WUJIE_QUEUE[this.name] = this.startAppQueue;
+      if (this.name && window.__WUJIE_QUEUE) {
+        window.__WUJIE_QUEUE[this.name] = this.startAppQueue;
+      }
     },
     destroy() {
       destroyApp(this.name);
@@ -103,6 +117,7 @@ const wujieVueOptions = {
   },
   beforeDestroy() {
     bus.$offAll(this.handleEmit);
+    clearStartAppQueue(this.name, this.startAppQueue);
   },
   render() {
     return h("div", {


### PR DESCRIPTION
## 背景

三个框架适配器（`wujie-react` / `wujie-vue2` / `wujie-vue3`）通过全局 `window.__WUJIE_QUEUE = { [name]: Promise链 }` 对同名子应用的 `startApp` 调用做串行化，避免并发竞态。

但该全局对象在**组件实例销毁后从不清理**：

- `window.__WUJIE_QUEUE[name]` 常驻 `window`，持有最后一次 `startApp` 的 Promise 链尾；
- 链尾的 `.then(this.startApp)` 闭包持有已卸载的组件实例，使其无法被 GC 回收；
- 反复挂载 / 卸载同名应用时，泄漏持续累积。

## 改动

统一在**组件销毁钩子**中按 `name` 清理（队列生命周期绑定组件实例，不与 core 的 `destroyApp` 耦合）：

- 新增 `clearStartAppQueue(name, queue)` helper：**仅当 `window.__WUJIE_QUEUE[name] === 当前实例链尾` 时才删除**。若已被同名新实例接管（in-out 过渡 / alive / 单例 remount），则跳过，保留串行化语义。
- `wujie-vue2` / `wujie-vue3`：在 `beforeDestroy` 中调用清理。
- `wujie-react`：新增此前缺失的 `componentWillUnmount` 调用清理；同时修复 `execStartApp` 中误用 `this.name`（React 组件上恒为 `undefined`）应为 `this.props.name` 的 bug。
- `execStartApp` 写入处增加 `name` 守卫，避免 `name` 为空时访问 `window.__WUJIE_QUEUE[undefined]` 报错。

## 兼容性

- 不改变正常串行化行为；`=== queue` 判断确保不会误删被新实例接管的队列。
- 无 API 变更，无破坏性改动。

## 测试计划

- [ ] 反复挂载/卸载同名子应用，确认 `window.__WUJIE_QUEUE` 中对应 key 在最后一个实例卸载后被移除。
- [ ] in-out 过渡同名切换（A 未销毁时 B 已挂载）下队列不被误删，串行化仍生效。
- [ ] alive 保活模式 remount 行为正常。
- [ ] React 适配器 `name` 正确写入队列（验证 `this.props.name` 修复）。