### PR TITLE
fix(wujie-core): destroy 时释放代理闭包并清理 $wujie 防止内存泄漏

### DIFF
--- a/packages/wujie-core/__test__/unit/destroy-provide-leak.test.ts
+++ b/packages/wujie-core/__test__/unit/destroy-provide-leak.test.ts
@@ -1,0 +1,69 @@
+/**
+ * 单元测试：sandbox.destroy() 对 iframeWindow.$wujie 的清理契约。
+ *
+ * provide 与 iframeWindow.$wujie 指向同一对象（patchIframeVariable）。destroy 时须在
+ * iframeWindow 上把 __WUJIE、$wujie 一并置 null；仅 this.provide = null 只断了 sandbox
+ * 侧引用，无法释放 provide 对象及其上的 shadowRoot / location。
+ */
+
+export {};
+
+import Wujie from "../../src/sandbox";
+
+describe("sandbox.destroy() 对 iframeWindow.$wujie 的清理契约", () => {
+  function createDestroyableSandbox() {
+    const iframe = window.document.createElement("iframe");
+    window.document.body.appendChild(iframe);
+    const iframeWindow: any = iframe.contentWindow;
+
+    const provide: any = { bus: {}, shadowRoot: {}, location: {} };
+    iframeWindow.__WUJIE = { id: "leak-test" };
+    iframeWindow.$wujie = provide;
+
+    const proxyRevoke = jest.fn();
+
+    const inst: any = Object.create(Wujie.prototype);
+    inst.id = "leak-test";
+    inst.provide = provide;
+    inst.shadowRoot = null;
+    inst.proxyLocation = null;
+    inst.proxyRevoke = proxyRevoke;
+    inst.iframe = iframe;
+    inst.bus = { $destroy: jest.fn() };
+    inst.eventCleanupTracker = { cleanupAll: jest.fn() };
+    inst.unmount = jest.fn().mockResolvedValue(undefined);
+    inst.styleSheetElements = [];
+    inst.dynamicScriptElements = [];
+    inst.deferredStyleObservers = [];
+
+    return { inst, iframeWindow, proxyRevoke };
+  }
+
+  test("destroy 后 iframeWindow.$wujie 与 __WUJIE 均被断链为 null", async () => {
+    const { inst, iframeWindow } = createDestroyableSandbox();
+
+    await inst.destroy();
+
+    expect(iframeWindow.$wujie).toBeNull();
+    expect(iframeWindow.__WUJIE).toBeNull();
+  });
+
+  test("destroy 后 sandbox 自身 provide / shadowRoot / proxyLocation 也被置空", async () => {
+    const { inst } = createDestroyableSandbox();
+
+    await inst.destroy();
+
+    expect(inst.provide).toBeNull();
+    expect(inst.shadowRoot).toBeNull();
+    expect(inst.proxyLocation).toBeNull();
+  });
+
+  test("destroy 后调用 proxyRevoke 释放代理闭包，并将其置空", async () => {
+    const { inst, proxyRevoke } = createDestroyableSandbox();
+
+    await inst.destroy();
+
+    expect(proxyRevoke).toHaveBeenCalledTimes(1);
+    expect(inst.proxyRevoke).toBeNull();
+  });
+});

--- a/packages/wujie-core/src/proxy.ts
+++ b/packages/wujie-core/src/proxy.ts
@@ -46,8 +46,9 @@ export function proxyGenerator(
   proxyWindow: Window;
   proxyDocument: Object;
   proxyLocation: Object;
+  proxyRevoke: () => void;
 } {
-  const proxyWindow = new Proxy(iframe.contentWindow, {
+  const { proxy: proxyWindow, revoke: revokeWindow } = Proxy.revocable(iframe.contentWindow, {
     get: (target: Window, p: PropertyKey): any => {
       // location进行劫持
       if (p === "location") {
@@ -80,7 +81,7 @@ export function proxyGenerator(
   });
 
   // proxy document
-  const proxyDocument = new Proxy(
+  const { proxy: proxyDocument, revoke: revokeDocument } = Proxy.revocable(
     {},
     {
       get: function (_fakeDocument, propKey) {
@@ -206,7 +207,7 @@ export function proxyGenerator(
   );
 
   // proxy location
-  const proxyLocation = new Proxy(
+  const { proxy: proxyLocation, revoke: revokeLocation } = Proxy.revocable(
     {},
     {
       get: function (_fakeLocation, propKey) {
@@ -252,7 +253,14 @@ export function proxyGenerator(
       },
     }
   );
-  return { proxyWindow, proxyDocument, proxyLocation };
+  // revoke 后引擎清空代理的 [[ProxyTarget]] / [[ProxyHandler]]，使捕获了 iframe / urlElement
+  // 的 handler 闭包不可达，从而释放对 iframe 的强引用
+  const proxyRevoke = () => {
+    revokeWindow();
+    revokeDocument();
+    revokeLocation();
+  };
+  return { proxyWindow, proxyDocument, proxyLocation, proxyRevoke };
 }
 
 /**
@@ -266,20 +274,26 @@ export function localGenerator(
 ): {
   proxyDocument: Object;
   proxyLocation: Object;
+  proxyRevoke: () => void;
 } {
+  // 降级模式无法使用 Proxy.revocable，改用可清空的引用：getter 闭包统一通过 iframeRef /
+  // sandboxRef / locationRef 这三个 let 绑定访问 DOM，proxyRevoke 时置 null，闭包即丢失
+  // 对 iframe 的强引用，斩断「主应用 → 代理闭包 → iframe」的引用链。
+  let iframeRef: HTMLIFrameElement | null = iframe;
+  let sandboxRef = iframe.contentWindow.__WUJIE;
+  let locationRef: Location | null = iframe.contentWindow.location;
   // 代理 document
   const proxyDocument = {};
-  const sandbox = iframe.contentWindow.__WUJIE;
   // 特殊处理
   Object.defineProperties(proxyDocument, {
     createElement: {
       get: () => {
         return function (...args) {
-          const element = iframe.contentWindow.__WUJIE_RAW_DOCUMENT_CREATE_ELEMENT__.apply(
-            iframe.contentDocument,
+          const element = iframeRef.contentWindow.__WUJIE_RAW_DOCUMENT_CREATE_ELEMENT__.apply(
+            iframeRef.contentDocument,
             args
           );
-          patchElementEffect(element, iframe.contentWindow);
+          patchElementEffect(element, iframeRef.contentWindow);
           return element;
         };
       },
@@ -287,29 +301,29 @@ export function localGenerator(
     createTextNode: {
       get: () => {
         return function (...args) {
-          const element = iframe.contentWindow.__WUJIE_RAW_DOCUMENT_CREATE_TEXT_NODE__.apply(
-            iframe.contentDocument,
+          const element = iframeRef.contentWindow.__WUJIE_RAW_DOCUMENT_CREATE_TEXT_NODE__.apply(
+            iframeRef.contentDocument,
             args
           );
-          patchElementEffect(element, iframe.contentWindow);
+          patchElementEffect(element, iframeRef.contentWindow);
           return element;
         };
       },
     },
     documentURI: {
-      get: () => (sandbox.proxyLocation as Location).href,
+      get: () => (sandboxRef?.proxyLocation as Location)?.href,
     },
     URL: {
-      get: () => (sandbox.proxyLocation as Location).href,
+      get: () => (sandboxRef?.proxyLocation as Location)?.href,
     },
     getElementsByTagName: {
       get() {
         return function (...args) {
           const tagName = args[0];
           if (tagName === "script") {
-            return iframe.contentDocument.scripts as any;
+            return iframeRef.contentDocument.scripts as any;
           }
-          return sandbox.document.getElementsByTagName(tagName) as any;
+          return sandboxRef.document.getElementsByTagName(tagName) as any;
         };
       },
     },
@@ -318,8 +332,8 @@ export function localGenerator(
         return function (...args) {
           const id = args[0];
           return (
-            (sandbox.document.getElementById(id) as any) ||
-            iframe.contentWindow.__WUJIE_RAW_DOCUMENT_HEAD__.querySelector(`#${id}`)
+            (sandboxRef.document.getElementById(id) as any) ||
+            iframeRef.contentWindow.__WUJIE_RAW_DOCUMENT_HEAD__.querySelector(`#${id}`)
           );
         };
       },
@@ -341,25 +355,24 @@ export function localGenerator(
     .forEach((key) => {
       Object.defineProperty(proxyDocument, key, {
         get: () => {
-          const value = sandbox.document?.[key];
-          return isCallable(value) ? value.bind(sandbox.document) : value;
+          const value = sandboxRef?.document?.[key];
+          return isCallable(value) ? value.bind(sandboxRef.document) : value;
         },
       });
     });
 
   // 代理 location
   const proxyLocation = {};
-  const location = iframe.contentWindow.location;
-  const locationKeys = Object.keys(location);
+  const locationKeys = Object.keys(locationRef);
   const constantKey = ["host", "hostname", "port", "protocol", "port"];
   constantKey.forEach((key) => {
     proxyLocation[key] = urlElement[key];
   });
   Object.defineProperties(proxyLocation, {
     href: {
-      get: () => location.href.replace(mainHostPath, appHostPath),
+      get: () => locationRef?.href.replace(mainHostPath, appHostPath),
       set: (value) => {
-        locationHrefSet(iframe, value, appHostPath);
+        locationHrefSet(iframeRef, value, appHostPath);
       },
     },
     reload: {
@@ -373,8 +386,14 @@ export function localGenerator(
     .filter((key) => !constantKey.concat(["href", "reload"]).includes(key))
     .forEach((key) => {
       Object.defineProperty(proxyLocation, key, {
-        get: () => (isCallable(location[key]) ? location[key].bind(location) : location[key]),
+        get: () => (isCallable(locationRef?.[key]) ? locationRef[key].bind(locationRef) : locationRef?.[key]),
       });
     });
-  return { proxyDocument, proxyLocation };
+  // 置空捕获的 DOM 引用，斩断 getter 闭包对 iframe / location / sandbox 的强引用
+  const proxyRevoke = () => {
+    iframeRef = null;
+    sandboxRef = null;
+    locationRef = null;
+  };
+  return { proxyDocument, proxyLocation, proxyRevoke };
 }

--- a/packages/wujie-core/src/sandbox.ts
+++ b/packages/wujie-core/src/sandbox.ts
@@ -61,6 +61,12 @@ export default class Wujie {
   public proxyDocument: Object;
   /** location代理 */
   public proxyLocation: Object;
+  /**
+   * 释放 window / document / location 代理。
+   * 代理的 handler 闭包捕获了 iframe / urlElement 等 DOM 引用，destroy 时调用此函数
+   * 解除代理与 handler 的关联，斩断「主应用 → 代理闭包 → iframe」的引用链。
+   */
+  public proxyRevoke: () => void;
   /** 事件中心 */
   public bus: EventBus;
   /** 容器 */
@@ -475,9 +481,11 @@ export default class Wujie {
       // patchElementEffect 给散落到主应用 DOM 上的 element 留了 baseURI / ownerDocument
       // getter，它们通过 iframeWindow.__WUJIE 动态读取。这里主动断链让残留 getter 立即
       // 降级到主 document，避免 element 把 sandbox 钉在内存中。
+      // __WUJIE / $wujie 均挂在 iframeWindow 上，destroy 时须一并置 null。
       if (iframeWindow) {
         try {
           iframeWindow.__WUJIE = null;
+          iframeWindow.$wujie = null;
         } catch (_) {
           /* noop: iframe 已 detach 时赋值可能抛错 */
         }
@@ -485,6 +493,14 @@ export default class Wujie {
       this.iframe.parentNode?.removeChild(this.iframe);
       this.iframe = null;
     }
+    // 释放 window / document / location 代理：解除代理与 handler 的关联，使捕获了 iframe /
+    // urlElement 的 handler 闭包不可达，斩断「主应用 → 代理闭包 → iframe」的引用链。
+    try {
+      this.proxyRevoke?.();
+    } catch (_) {
+      /* noop: 代理已释放时重复调用可能抛错 */
+    }
+    this.proxyRevoke = null;
     // 反向解绑 patchDocumentEffect / patchWindowEffect 在主 window / document 上挂的副作用
     this.eventCleanupTracker.cleanupAll();
     deleteWujieById(this.id);
@@ -622,11 +638,17 @@ export default class Wujie {
     this.iframe = iframeGenerator(this, attrs, mainHostPath, appHostPath, appRoutePath);
 
     if (this.degrade) {
-      const { proxyDocument, proxyLocation } = localGenerator(this.iframe, urlElement, mainHostPath, appHostPath);
+      const { proxyDocument, proxyLocation, proxyRevoke } = localGenerator(
+        this.iframe,
+        urlElement,
+        mainHostPath,
+        appHostPath
+      );
       this.proxyDocument = proxyDocument;
       this.proxyLocation = proxyLocation;
+      this.proxyRevoke = proxyRevoke;
     } else {
-      const { proxyWindow, proxyDocument, proxyLocation } = proxyGenerator(
+      const { proxyWindow, proxyDocument, proxyLocation, proxyRevoke } = proxyGenerator(
         this.iframe,
         urlElement,
         mainHostPath,
@@ -635,6 +657,7 @@ export default class Wujie {
       this.proxy = proxyWindow;
       this.proxyDocument = proxyDocument;
       this.proxyLocation = proxyLocation;
+      this.proxyRevoke = proxyRevoke;
     }
     this.provide.location = this.proxyLocation;
 


### PR DESCRIPTION
## Summary

- **代理可撤销**：`proxyGenerator` 改用 `Proxy.revocable`，`destroy` 时通过 `proxyRevoke` 解除 handler 与 iframe / urlElement 的关联，避免「主应用 → 代理闭包 → iframe」强引用链导致无法 GC。
- **降级模式断链**：`localGenerator` 将 iframe / sandbox / location 改为可置空的 `let` 引用，`proxyRevoke` 时统一置 `null`，在无法使用 revocable 时同样释放闭包捕获的 DOM。
- **destroy 补全清理**：`sandbox.destroy()` 除原有 `__WUJIE = null` 外，增加 `iframeWindow.$wujie = null` 与 `proxyRevoke()` 调用；`provide` 与 `$wujie` 同源，仅清 sandbox 侧无法释放 shadowRoot / location 等。
- **单元测试**：新增 `destroy-provide-leak.test.ts`，覆盖 destroy 后 `$wujie` / `__WUJIE`、sandbox 字段及 `proxyRevoke` 调用契约。

## Test plan

- [x] `cd packages/wujie-core && pnpm run test:unit -- destroy-provide-leak`
- [ ] 主应用反复 mount / destroy 子应用，用 DevTools Memory 对比 detached iframe / Wujie 实例是否下降
- [ ] 降级模式（`degrade: true`）下同样执行 destroy，确认无回归