### PR TITLE
fix: 修复异步加载 CSS 时重复插入的问题

### DIFF
--- a/packages/wujie-core/src/effect.ts
+++ b/packages/wujie-core/src/effect.ts
@@ -297,37 +297,43 @@ function rewriteAppendOrInsertChild(opts: {
 
           // 拉取 css 内容并以 <style> 注入子应用、回调 link 的 load/error 事件。
           // 抽成闭包以便「append 时已有 href」与「append 后才 setAttribute('href')」两条路径复用。
-          const loadStyleSheet = (realHref: string, linkElement: HTMLLinkElement) => {
-            const attrHref = linkElement.getAttribute("href");
-            const styleHref = attrHref ? getAbsolutePath(attrHref, (proxyLocation as Location).href) : realHref;
-            const exclude = isMatchUrl(styleHref, getEffectLoaders("cssExcludes", plugins));
-            if (!styleHref || exclude) return;
-            getExternalStyleSheets(
-              [{ src: styleHref, ignore: isMatchUrl(styleHref, getEffectLoaders("cssIgnores", plugins)) }],
-              fetch,
-              lifecycles.loadError
-            ).forEach(({ src, ignore, contentPromise }) =>
-              contentPromise.then(
-                (content) => {
-                  // 处理 ignore 样式
-                  const rawAttrs = parseTagAttributes(linkElement.outerHTML);
+         const loadStyleSheet = (realHref: string, linkElement: HTMLLinkElement) => {
+           const attrHref = linkElement.getAttribute("href");
+           const styleHref = attrHref ? getAbsolutePath(attrHref, (proxyLocation as Location).href) : realHref;
+           const exclude = isMatchUrl(styleHref, getEffectLoaders("cssExcludes", plugins));
+           if (!styleHref || exclude) return;
+
+           // 立即创建占位 <style> 元素，避免异步加载期间重复插入
+           // 保留原始 link 的属性（如 class），以便 checkLinkAndLoad 等去重逻辑能找到
+           const rawAttrs = parseTagAttributes(linkElement.outerHTML);
+           const placeholderElement = iframeDocument.createElement("style");
+           setAttrsToElement(placeholderElement, rawAttrs);
+           placeholderElement.setAttribute("data-wujie-css-href", styleHref);
+           rawDOMAppendOrInsertBefore.call(this, placeholderElement, refChild);
+
+           getExternalStyleSheets(
+             [{ src: styleHref, ignore: isMatchUrl(styleHref, getEffectLoaders("cssIgnores", plugins)) }],
+             fetch,
+             lifecycles.loadError
+           ).forEach(({ src, ignore, contentPromise }) =>
+             contentPromise.then(
+               (content) => {
                   if (ignore && src) {
                     // 忽略的元素应该直接把对应元素插入，而不是用新的 link 标签进行替代插入，保证 element 的上下文正常
+                   // 移除占位元素，插入原始 link
+                   placeholderElement.parentNode?.removeChild(placeholderElement);
                     rawDOMAppendOrInsertBefore.call(this, linkElement, refChild);
                   } else {
-                    // 记录js插入样式，子应用重新激活时恢复
-                    const stylesheetElement = iframeDocument.createElement("style");
-                    // 处理css-loader插件
-                    const cssLoader = getCssLoader({ plugins, replace });
-                    stylesheetElement.innerHTML = cssLoader(content, src, curUrl);
-                    styleSheetElements.push(stylesheetElement);
-                    setAttrsToElement(stylesheetElement, rawAttrs);
-                    rawDOMAppendOrInsertBefore.call(this, stylesheetElement, refChild);
-                    // 处理样式补丁
-                    handleStylesheetElementPatch(stylesheetElement, sandbox);
-                    manualInvokeElementEvent(linkElement, "load");
-                  }
-                  if (element === linkElement) element = null;
+                   // 填充 CSS 内容到占位元素
+                   // 处理css-loader插件
+                   const cssLoader = getCssLoader({ plugins, replace });
+                   placeholderElement.innerHTML = cssLoader(content, src, curUrl);
+                   styleSheetElements.push(placeholderElement);
+                   // 处理样式补丁
+                   handleStylesheetElementPatch(placeholderElement, sandbox);
+                   manualInvokeElementEvent(linkElement, "load");
+                 }
+                 if (element === linkElement) element = null;
                 },
                 () => {
                   manualInvokeElementEvent(linkElement, "error");


### PR DESCRIPTION
## 问题

子应用调用 `document.head.appendChild(link)` 后，wujie 异步加载 CSS。在 CSS 加载完成前，`checkLinkAndLoad` 等去重检查无法找到已存在的元素，导致相同的 CSS 被重复插入多次。

## 场景示例

- TDesign IconFont 组件的 `checkLinkAndLoad` 函数
- React StrictMode 下 useEffect 执行两次
- 快速连续调用相同 CSS 加载

## 解决方案

- 在异步加载 CSS 前，立即创建占位 `<style>` 元素并插入 DOM
- 保留原始 `<link>` 的属性（如 class），以便去重逻辑能找到
- CSS 加载完成后填充内容到占位元素

## 修改文件

### effect.ts
`loadStyleSheet` 函数：
- 提前解析属性并创建占位元素
- 立即插入 DOM（关键改动）
- CSS 加载完成后填充内容或处理 ignore 情况

## 测试

- [ ] TDesign IconFont 组件不再重复加载 CSS
- [ ] React StrictMode 下 CSS 只加载一次
- [ ] 普通 CSS 加载流程不受影响