### PR TITLE
fix: 修复子应用刷新场景 destroy 竞态导致的内存泄漏

### DIFF
--- a/packages/wujie-core/__test__/unit/destroy-order.test.ts
+++ b/packages/wujie-core/__test__/unit/destroy-order.test.ts
@@ -1,0 +1,122 @@
+/**
+ * 单元测试：sandbox.destroy() 同步移除 map、防重入，以及 destroyApp 异步契约。
+ *
+ * 修复刷新场景下 destroy 竞态：deleteWujieById 须在 await unmount 之前同步执行，
+ * 确保 disconnectedCallback / startApp 通过 getWujieById 拿到 null。
+ */
+
+export {};
+
+import Wujie from "../../src/sandbox";
+import { addSandboxCacheWithWujie, getWujieById, idToSandboxCacheMap } from "../../src/common";
+import { destroyApp } from "../../src/index";
+
+function createMinimalDestroyableSandbox(id: string) {
+  const iframe = window.document.createElement("iframe");
+  window.document.body.appendChild(iframe);
+  const iframeWindow: any = iframe.contentWindow;
+
+  const inst: any = Object.create(Wujie.prototype);
+  inst.id = id;
+  inst.destroyed = false;
+  inst.provide = null;
+  inst.shadowRoot = null;
+  inst.proxyLocation = null;
+  inst.proxyRevoke = jest.fn();
+  inst.iframe = iframe;
+  inst.bus = { $destroy: jest.fn() };
+  inst.eventCleanupTracker = { cleanupAll: jest.fn() };
+  inst.styleSheetElements = [];
+  inst.dynamicScriptElements = [];
+  inst.fontStyleSheetElements = [];
+  inst.deferredStyleObservers = [];
+  inst.unmount = jest.fn().mockResolvedValue(undefined);
+
+  if (iframeWindow) {
+    iframeWindow.__WUJIE = { id };
+    iframeWindow.$wujie = {};
+  }
+
+  return { inst, iframe };
+}
+
+describe("sandbox.destroy() 同步移除 map 与防重入", () => {
+  beforeEach(() => {
+    idToSandboxCacheMap.clear();
+  });
+
+  test("destroy 应在 await unmount 之前同步从 map 移除 sandbox", async () => {
+    const { inst } = createMinimalDestroyableSandbox("order-test");
+    let unmountResolve: () => void;
+    const unmountGate = new Promise<void>((resolve) => {
+      unmountResolve = resolve;
+    });
+
+    addSandboxCacheWithWujie("order-test", inst);
+    expect(getWujieById("order-test")).toBe(inst);
+
+    inst.unmount = jest.fn().mockImplementation(() => {
+      expect(getWujieById("order-test")).toBe(null);
+      return unmountGate;
+    });
+
+    const destroyPromise = inst.destroy();
+    expect(getWujieById("order-test")).toBe(null);
+
+    unmountResolve!();
+    await destroyPromise;
+  });
+
+  test("destroy 防重入：第二次调用不应重复执行 unmount", async () => {
+    const { inst } = createMinimalDestroyableSandbox("reentry-test");
+    addSandboxCacheWithWujie("reentry-test", inst);
+
+    await inst.destroy();
+    await inst.destroy();
+
+    expect(inst.unmount).toHaveBeenCalledTimes(1);
+    expect(inst.destroyed).toBe(true);
+  });
+
+  test("有 setupApp options 时，destroy 同步段应只移除 wujie 实例、保留 options", async () => {
+    const { inst } = createMinimalDestroyableSandbox("options-test");
+    const options = { name: "options-test", url: "//example.com" };
+    const { addSandboxCacheWithOptions, getOptionsById } = require("../../src/common");
+
+    addSandboxCacheWithOptions("options-test", options);
+    addSandboxCacheWithWujie("options-test", inst);
+
+    const destroyPromise = inst.destroy();
+    expect(getWujieById("options-test")).toBe(null);
+    expect(getOptionsById("options-test")).toBe(options);
+
+    await destroyPromise;
+  });
+});
+
+describe("destroyApp", () => {
+  beforeEach(() => {
+    idToSandboxCacheMap.clear();
+  });
+
+  test("应 await sandbox.destroy 完成后再返回", async () => {
+    const { inst } = createMinimalDestroyableSandbox("async-destroy-app");
+    let destroyFinished = false;
+
+    addSandboxCacheWithWujie("async-destroy-app", inst);
+    inst.destroy = jest.fn().mockImplementation(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+      destroyFinished = true;
+    });
+
+    const promise = destroyApp("async-destroy-app");
+    expect(destroyFinished).toBe(false);
+    await promise;
+    expect(destroyFinished).toBe(true);
+    expect(inst.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  test("map 中无 sandbox 时应安全返回", async () => {
+    await expect(destroyApp("nonexistent")).resolves.toBeUndefined();
+  });
+});

--- a/packages/wujie-core/src/index.ts
+++ b/packages/wujie-core/src/index.ts
@@ -372,9 +372,9 @@ export function preloadApp(preOptions: preOptions): void {
 /**
  * 销毁无界APP
  */
-export function destroyApp(id: string): void {
+export async function destroyApp(id: string): Promise<void> {
   const sandbox = getWujieById(id);
   if (sandbox) {
-    sandbox.destroy();
+    await sandbox.destroy();
   }
 }

--- a/packages/wujie-core/src/sandbox.ts
+++ b/packages/wujie-core/src/sandbox.ts
@@ -99,6 +99,8 @@ export default class Wujie {
   public activeFlag: boolean;
   /** 子应用mount标志 */
   public mountFlag: boolean;
+  /** 子应用销毁标志，防止 destroy 被并发重复执行 */
+  public destroyed = false;
   /** 路由同步标志 */
   public sync: boolean;
   /** 子应用短路径替换，路由同步时生效 */
@@ -432,6 +434,13 @@ export default class Wujie {
 
   /** 销毁子应用 */
   public async destroy() {
+    // 防重入：极端时序下 destroyApp / disconnectedCallback / startApp 可能并发触发，
+    // 标志位确保同一实例只执行一次完整销毁。
+    if (this.destroyed) return;
+    this.destroyed = true;
+    // 同步从全局 map 移除自身：确保 await 挂起期间并发的 disconnectedCallback /
+    // startApp 通过 getWujieById 拿到 null，避免对同一实例重复 destroy（竞态根因）。
+    deleteWujieById(this.id);
     await this.unmount();
     // 释放动态样式 / 脚本节点（unmount 阶段保留以便 rebuildStyleSheets 复用，destroy 阶段才彻底清）
     this.clearStyleSheets();
@@ -509,7 +518,6 @@ export default class Wujie {
     this.proxyRevoke = null;
     // 反向解绑 patchDocumentEffect / patchWindowEffect 在主 window / document 上挂的副作用
     this.eventCleanupTracker.cleanupAll();
-    deleteWujieById(this.id);
   }
 
   /**

--- a/packages/wujie-core/src/shadow.ts
+++ b/packages/wujie-core/src/shadow.ts
@@ -20,7 +20,7 @@ import Wujie from "./sandbox";
 import { initBase, patchElementEffect } from "./iframe";
 import { patchRenderEffect } from "./effect";
 import { getCssLoader, getPresetLoaders } from "./plugin";
-import { getAbsolutePath, getContainer, getCurUrl, isFunction, setAttrsToElement } from "./utils";
+import { getAbsolutePath, getContainer, getCurUrl, isFunction, setAttrsToElement, warn } from "./utils";
 
 const cssSelectorMap = {
   ":root": ":host",
@@ -48,9 +48,9 @@ export function handleWujieAppDisconnect(sandbox: Wujie | null | undefined): voi
   const iframeWindow = sandbox.iframe?.contentWindow;
   const isRebuildMode = !sandbox.alive && !isFunction(iframeWindow?.__WUJIE_MOUNT);
   if (isRebuildMode) {
-    sandbox.destroy();
+    sandbox.destroy().catch((e) => warn(`destroy error: ${e}`));
   } else {
-    sandbox.unmount();
+    sandbox.unmount().catch((e) => warn(`unmount error: ${e}`));
   }
 }
 

--- a/packages/wujie-react/index.js
+++ b/packages/wujie-react/index.js
@@ -27,9 +27,13 @@ export default class WujieReact extends React.PureComponent {
 
   destroy = null;
 
+  isUnmounted = false;
+
   startAppQueue = Promise.resolve();
 
   startApp = async () => {
+    // 拦截组件卸载后仍残留在 __WUJIE_QUEUE Promise 链中的 .then(startApp) 幽灵执行
+    if (this.isUnmounted) return;
     try {
       const props = this.props;
       const { current: el } = this.state.myRef;
@@ -37,12 +41,18 @@ export default class WujieReact extends React.PureComponent {
         ...props,
         el,
       });
+      // 异步创建跨越了卸载点，兜底销毁孤儿 sandbox
+      if (this.isUnmounted && typeof this.destroy === "function") {
+        this.destroy();
+      }
     } catch (error) {
       console.log(error);
     }
   };
 
   execStartApp = () => {
+    // 卸载后残留触发不应再入队
+    if (this.isUnmounted) return;
     this.startAppQueue = this.startAppQueue.then(this.startApp);
     if (this.props.name && window.__WUJIE_QUEUE) {
       window.__WUJIE_QUEUE[this.props.name] = this.startAppQueue;
@@ -73,6 +83,7 @@ export default class WujieReact extends React.PureComponent {
   }
 
   componentWillUnmount() {
+    this.isUnmounted = true;
     clearStartAppQueue(this.props.name, this.startAppQueue);
   }
 

--- a/packages/wujie-vue2/index.js
+++ b/packages/wujie-vue2/index.js
@@ -46,6 +46,7 @@ const wujieVueOptions = {
   data() {
     return {
       startAppQueue: Promise.resolve(),
+      isUnmounted: false,
     };
   },
   mounted() {
@@ -74,9 +75,11 @@ const wujieVueOptions = {
       this.$emit(event, ...args);
     },
     async startApp() {
+      // 拦截组件卸载后仍残留在 __WUJIE_QUEUE Promise 链中的 .then(startApp) 幽灵执行
+      if (this.isUnmounted) return;
       try {
         // $props 是vue 2.2版本才有的属性，所以这里直接全部写一遍
-        await rawStartApp({
+        const destroy = await rawStartApp({
           name: this.name,
           url: this.url,
           el: this.$refs.wujie,
@@ -102,11 +105,17 @@ const wujieVueOptions = {
           iframeAddEventListeners: this.iframeAddEventListeners,
           iframeOnEvents: this.iframeOnEvents,
         });
+        // 异步创建跨越了卸载点，兜底销毁孤儿 sandbox
+        if (this.isUnmounted && typeof destroy === "function") {
+          destroy();
+        }
       } catch (error) {
         console.log(error);
       }
     },
     execStartApp() {
+      // 卸载后 watch 残留触发不应再入队
+      if (this.isUnmounted) return;
       this.startAppQueue = this.startAppQueue.then(this.startApp);
       if (this.name && window.__WUJIE_QUEUE) {
         window.__WUJIE_QUEUE[this.name] = this.startAppQueue;
@@ -117,6 +126,7 @@ const wujieVueOptions = {
     },
   },
   beforeDestroy() {
+    this.isUnmounted = true;
     bus.$offAll(this.handleEmit);
     clearStartAppQueue(this.name, this.startAppQueue);
   },

--- a/packages/wujie-vue3/index.js
+++ b/packages/wujie-vue3/index.js
@@ -46,6 +46,7 @@ const wujieVueOptions = {
   data() {
     return {
       startAppQueue: Promise.resolve(),
+      isUnmounted: false,
     };
   },
   mounted() {
@@ -74,8 +75,10 @@ const wujieVueOptions = {
       this.$emit(event, ...args);
     },
     async startApp() {
+      // 拦截组件卸载后仍残留在 __WUJIE_QUEUE Promise 链中的 .then(startApp) 幽灵执行
+      if (this.isUnmounted) return;
       try {
-        await rawStartApp({
+        const destroy = await rawStartApp({
           name: this.name,
           url: this.url,
           el: this.$refs.wujie,
@@ -101,11 +104,17 @@ const wujieVueOptions = {
           iframeAddEventListeners: this.iframeAddEventListeners,
           iframeOnEvents: this.iframeOnEvents,
         });
+        // 异步创建跨越了卸载点，兜底销毁孤儿 sandbox
+        if (this.isUnmounted && typeof destroy === "function") {
+          destroy();
+        }
       } catch (error) {
         console.log(error);
       }
     },
     execStartApp() {
+      // 卸载后 watch 残留触发不应再入队
+      if (this.isUnmounted) return;
       this.startAppQueue = this.startAppQueue.then(this.startApp);
       if (this.name && window.__WUJIE_QUEUE) {
         window.__WUJIE_QUEUE[this.name] = this.startAppQueue;
@@ -116,6 +125,7 @@ const wujieVueOptions = {
     },
   },
   beforeDestroy() {
+    this.isUnmounted = true;
     bus.$offAll(this.handleEmit);
     clearStartAppQueue(this.name, this.startAppQueue);
   },


### PR DESCRIPTION
## Summary

- 将 `deleteWujieById` 移至 `sandbox.destroy()` 同步段（`await unmount()` 之前），并增加 `destroyed` 防重入标志，切断 `destroyApp` / `disconnectedCallback` / `startApp` 对同一 sandbox 的并发销毁竞态
- `destroyApp` 改为 `async`，调用方可 `await` 销毁完成；`handleWujieAppDisconnect` 为 fire-and-forget 的 `destroy`/`unmount` 补充 `.catch` 兜底
- Vue2/Vue3/React 适配器增加 `isUnmounted` 守卫，拦截 `__WUJIE_QUEUE` 残留微任务，并在异步 `startApp` 跨越卸载点时兜底销毁孤儿 sandbox
- 新增 `destroy-order.test.ts` 单测覆盖 map 同步移除、防重入与 `destroyApp` 异步契约

## Test plan

- [x] `cd packages/wujie-core && npm run test:unit`（20 suites / 94 tests 通过）
- [ ] 主应用 Tab 关闭后快速重开同名子应用，Chrome Memory 面板确认 iframe / sandbox 无累积
- [ ] 业务层 `onBeforeUnmount` 中 `await destroyApp(name)` 验证销毁时序正常
- [ ] 保活 / 单例 / 重建三种模式 smoke test


Made with [Cursor](https://cursor.com)