### PR TITLE
feat: 新增 refreshApp API 支持子应用全量重建刷新

### DIFF
--- a/packages/wujie-core/src/index.ts
+++ b/packages/wujie-core/src/index.ts
@@ -378,3 +378,13 @@ export async function destroyApp(id: string): Promise<void> {
     await sandbox.destroy();
   }
 }
+
+/**
+ * 刷新无界APP
+ * 先销毁当前子应用实例，再以传入配置全量重建（等价于「重建模式」）
+ * 等待 destroyApp 完成后再 startApp，避免销毁未结束就重启导致的竞态
+ */
+export async function refreshApp(startOptions: startOptions): Promise<Function | void> {
+  await destroyApp(startOptions.name);
+  return startApp(startOptions);
+}

--- a/packages/wujie-react/index.d.ts
+++ b/packages/wujie-react/index.d.ts
@@ -1,4 +1,4 @@
-import { bus, preloadApp, destroyApp, setupApp } from "wujie";
+import { bus, preloadApp, destroyApp, setupApp, refreshApp } from "wujie";
 import PropTypes from "prop-types";
 import React from "react";
 
@@ -32,4 +32,5 @@ export default class WujieReact extends React.PureComponent {
   static setupApp: typeof setupApp;
   static preloadApp: typeof preloadApp;
   static destroyApp: typeof destroyApp;
+  static refreshApp: typeof refreshApp;
 }

--- a/packages/wujie-react/index.js
+++ b/packages/wujie-react/index.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { bus, preloadApp, startApp, destroyApp, setupApp } from "wujie";
+import { bus, preloadApp, startApp, destroyApp, setupApp, refreshApp } from "wujie";
 
 /**
  * 清理全局 startApp 串行队列，防止组件销毁后 window.__WUJIE_QUEUE 长期持有
@@ -20,6 +20,7 @@ export default class WujieReact extends React.PureComponent {
   static setupApp = setupApp;
   static preloadApp = preloadApp;
   static destroyApp = destroyApp;
+  static refreshApp = refreshApp;
 
   state = {
     myRef: React.createRef(),
@@ -57,6 +58,14 @@ export default class WujieReact extends React.PureComponent {
     if (this.props.name && window.__WUJIE_QUEUE) {
       window.__WUJIE_QUEUE[this.props.name] = this.startAppQueue;
     }
+  };
+
+  // 销毁当前子应用实例并复用组件 props 全量重建
+  refresh = async () => {
+    if (this.isUnmounted) return;
+    await destroyApp(this.props.name);
+    this.execStartApp();
+    return this.startAppQueue;
   };
 
   componentDidMount() {

--- a/packages/wujie-vue2/index.d.ts
+++ b/packages/wujie-vue2/index.d.ts
@@ -1,11 +1,12 @@
 import { VueConstructor } from "vue";
-import { bus, preloadApp, destroyApp, setupApp } from "wujie";
+import { bus, preloadApp, destroyApp, setupApp, refreshApp } from "wujie";
 
 declare const WujieVue: {
   bus: typeof bus;
   setupApp: typeof setupApp;
   preloadApp: typeof preloadApp;
   destroyApp: typeof destroyApp;
+  refreshApp: typeof refreshApp;
   install: (Vue: VueConstructor) => void;
 };
 

--- a/packages/wujie-vue2/index.js
+++ b/packages/wujie-vue2/index.js
@@ -1,5 +1,5 @@
 import Vue from "vue";
-import { bus, preloadApp, startApp as rawStartApp, destroyApp, setupApp } from "wujie";
+import { bus, preloadApp, startApp as rawStartApp, destroyApp, setupApp, refreshApp } from "wujie";
 
 /**
  * 清理全局 startApp 串行队列，防止组件销毁后 window.__WUJIE_QUEUE 长期持有
@@ -124,6 +124,13 @@ const wujieVueOptions = {
     destroy() {
       destroyApp(this.name);
     },
+    // 销毁当前子应用实例并复用组件 props 全量重建
+    async refresh() {
+      if (this.isUnmounted) return;
+      await destroyApp(this.name);
+      this.execStartApp();
+      return this.startAppQueue;
+    },
   },
   beforeDestroy() {
     this.isUnmounted = true;
@@ -148,6 +155,7 @@ WujieVue.setupApp = setupApp;
 WujieVue.preloadApp = preloadApp;
 WujieVue.bus = bus;
 WujieVue.destroyApp = destroyApp;
+WujieVue.refreshApp = refreshApp;
 WujieVue.install = function (Vue) {
   Vue.component("WujieVue", WujieVue);
 };

--- a/packages/wujie-vue3/index.d.ts
+++ b/packages/wujie-vue3/index.d.ts
@@ -1,4 +1,4 @@
-import { bus, preloadApp, destroyApp, setupApp } from "wujie";
+import { bus, preloadApp, destroyApp, setupApp, refreshApp } from "wujie";
 import type { DefineComponent, Plugin } from 'vue';
 
 declare const WujieVue: DefineComponent & Plugin & {
@@ -6,6 +6,7 @@ declare const WujieVue: DefineComponent & Plugin & {
   setupApp: typeof setupApp;
   preloadApp: typeof preloadApp;
   destroyApp: typeof destroyApp;
+  refreshApp: typeof refreshApp;
 };
 
 export default WujieVue;

--- a/packages/wujie-vue3/index.js
+++ b/packages/wujie-vue3/index.js
@@ -1,4 +1,4 @@
-import { bus, preloadApp, startApp as rawStartApp, destroyApp, setupApp } from "wujie";
+import { bus, preloadApp, startApp as rawStartApp, destroyApp, setupApp, refreshApp } from "wujie";
 import { h, defineComponent } from "vue";
 
 /**
@@ -123,6 +123,13 @@ const wujieVueOptions = {
     destroy() {
       destroyApp(this.name);
     },
+    // 销毁当前子应用实例并复用组件 props 全量重建
+    async refresh() {
+      if (this.isUnmounted) return;
+      await destroyApp(this.name);
+      this.execStartApp();
+      return this.startAppQueue;
+    },
   },
   beforeDestroy() {
     this.isUnmounted = true;
@@ -147,6 +154,7 @@ WujieVue.setupApp = setupApp;
 WujieVue.preloadApp = preloadApp;
 WujieVue.bus = bus;
 WujieVue.destroyApp = destroyApp;
+WujieVue.refreshApp = refreshApp;
 WujieVue.install = function (app) {
   app.component("WujieVue", WujieVue);
 };


### PR DESCRIPTION
## Summary

- 在 `wujie` core 层新增 `refreshApp(startOptions)`：先 `await destroyApp(name)`，再 `startApp(startOptions)`，等价于「重建模式」，子应用 JS 与状态全量重置
- 在 `wujie-vue2` / `wujie-vue3` / `wujie-react` 适配层暴露静态方法 `refreshApp`，以及组件实例无参方法 `refresh()`（复用组件 props 与容器，无需用户重复填写启动参数）
- 复用现有生命周期：`beforeUnmount/afterUnmount` → `beforeLoad/beforeMount/afterMount`，不新增专用生命周期钩子

## Related issues

- Closes #740 — 用户期望提供 `reloadApp`/`refreshApp` 刷新子应用状态

以下 issue 与「刷新」关键词相关，但**不由本 PR 直接解决**，暂不关闭：

| Issue | 原因 |
|-------|------|
| #732（已关闭） | 刷新后 ref 丢失问题，属于 destroy 竞态，已在 #1098 修复 |
| #578 | Firefox 浏览器刷新导致 unmount 失败，是浏览器 F5 场景 |
| #1007 / #1002 / #735 等 | 浏览器刷新后路由丢失，属于 sync/路由同步问题 |

## Test plan

- [ ] `import { refreshApp } from 'wujie'`，对已运行的子应用调用 `refreshApp({ name, url, el, ... })`，确认子应用被销毁并全量重建
- [ ] Vue/React 组件通过 `ref` 调用 `refresh()`，确认无需重填 props 即可刷新
- [ ] 保活（`alive: true`）子应用调用 `refreshApp` 后确认走重建而非保活分支
- [ ] 快速连续调用 `refresh()` 确认串行队列无竞态（依赖 #1098 的 async `destroyApp`）


Made with [Cursor](https://cursor.com)