### PR TITLE
docs: 补充 refreshApp 与 clearAssetsCache API 文档

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -200,6 +200,14 @@ export default defineConfig({
               text: "destroyApp",
               link: "/api/destroyApp",
             },
+            {
+              text: "refreshApp",
+              link: "/api/refreshApp",
+            },
+            {
+              text: "clearAssetsCache",
+              link: "/api/clearAssetsCache",
+            },
           ],
         },
         {

--- a/docs/api/clearAssetsCache.md
+++ b/docs/api/clearAssetsCache.md
@@ -1,0 +1,48 @@
+# clearAssetsCache
+
+- **类型：** `Function`
+
+- **参数：** `host?: string | string[]`
+
+- **返回值：** `void`
+
+清空无界模块级资源缓存，包括 `styleCache`、`scriptCache`、`embedHTMLCache`。子应用卸载（`destroyApp`）时不会自动清理这些缓存；多 host 子应用切换或热更新场景下，旧资源可能继续被命中，可调用此 API 主动失效。
+
+::: tip 使用场景
+
+- 子应用静态资源热更新后，需要强制重新拉取 html / js / css
+- 同一主应用下挂载多个不同 host 的子应用，切换后希望清理指定 host 的缓存
+- 排查资源缓存导致的「页面不更新」问题
+
+:::
+
+## host
+
+- **类型：** `string | string[]`
+
+- **详情：**
+
+  - 不传参：清空全部资源缓存
+  - 传入单个 host（如 `"https://a.com"`）：只清空缓存 key 以该前缀匹配的条目
+  - 传入 host 数组：批量清理多个前缀
+
+## 示例
+
+```javascript
+import { clearAssetsCache } from "wujie";
+
+// 清空全部缓存
+clearAssetsCache();
+
+// 只清理指定 host
+clearAssetsCache("https://a.com");
+
+// 批量清理
+clearAssetsCache(["https://a.com", "https://b.com"]);
+```
+
+::: warning 注意
+
+此 API 仅清理无界内部的资源加载缓存，不会销毁子应用实例。若需全量重建子应用，请使用 [refreshApp](/api/refreshApp.html) 或 [destroyApp](/api/destroyApp.html) + [startApp](/api/startApp.html)。
+
+:::

--- a/docs/api/refreshApp.md
+++ b/docs/api/refreshApp.md
@@ -1,0 +1,50 @@
+# refreshApp
+
+- **类型：** `Function`
+
+- **参数：** `startOptions`（与 [startApp](/api/startApp.html) 相同）
+
+- **返回值：** `Promise<Function | void>`
+
+主动刷新子应用：先调用 [destroyApp](/api/destroyApp.html) 销毁当前实例，再以传入配置调用 [startApp](/api/startApp.html) 全量重建。内部会等待 `destroyApp` 完成后再 `startApp`，避免销毁未结束就重启导致的竞态问题。
+
+等价于手动串联 `destroyApp(name)` + `startApp(startOptions)`，由框架保证调用顺序。
+
+::: tip 使用场景
+
+- 子应用处于 [重建模式](/guide/mode.html#重建模式)，需要强制全量重建以清空状态、重新加载资源
+- 子应用代码或静态资源已更新，需要销毁旧实例后重新拉取
+- 使用 Vue / React 组件封装时，也可通过组件 ref 调用 [refresh()](/pack/#refresh)，**无需传参**，自动复用组件当前 props 全量重建
+
+:::
+
+::: warning 注意
+
+- 刷新会销毁当前子应用实例，承载子应用的 `iframe` 和 `shadowRoot` 都会被销毁，过程中可能出现短暂白屏
+- `name`、`replace`、`fetch`、`alive`、`degrade` 等参数须与首次 `startApp` 保持一致，否则渲染可能出现异常
+- 若子应用后续还会被打开，一般无需主动刷新；仅在需要强制重建时使用
+
+:::
+
+## 示例
+
+```javascript
+import { refreshApp } from "wujie";
+
+await refreshApp({
+  name: "vue3",
+  url: "https://xxx.com/",
+  el: document.querySelector("#container"),
+});
+```
+
+使用 Vue / React 组件封装时：
+
+```javascript
+// 静态方法 refreshApp，参数与 startApp 相同
+import WujieVue from "wujie-vue3";
+await WujieVue.refreshApp({ name: "vue3", url: "...", el: "..." });
+
+// 组件实例方法 refresh()，无需传参，自动复用组件当前 props 全量重建
+await this.$refs.wujie.refresh();
+```

--- a/docs/guide/mode.md
+++ b/docs/guide/mode.md
@@ -38,3 +38,5 @@ collapsable: false
 子应用既没有设置为保活模式，也没有进行生命周期的改造则进入了重建模式，每次页面切换不仅会销毁承载子应用`dom`的`webcomponent`，还会销毁承载子应用`js`的`iframe`，相应的`wujie`实例和子应用实例都会被销毁
 
 重建模式下改变 [url](/api/startApp.html#url) 子应用的路由会跳转对应路由，但是在 [路由同步](/guide/sync.html) 场景并且子应用的路由同步参数已经同步到主应用`url`上时则无法生效，因为改变`url`后会导致子应用销毁重新渲染，此时如果有同步参数则同步参数的优先级最高
+
+需要主动触发全量重建时，可使用 [refreshApp](/api/refreshApp.html)

--- a/docs/guide/preload.md
+++ b/docs/guide/preload.md
@@ -14,3 +14,7 @@
 只需要在`preloadApp`中将 [exec](/api/preloadApp.html#exec) 设置为`true`即可
 
 由于子应用提前渲染可能会导致阻塞主应用的线程，所以无界提供了类似 [react-fiber](https://github.com/acdlite/react-fiber-architecture) 方式来防止阻塞线程，详见 [fiber](/api/startApp.html#fiber)
+
+## 清理资源缓存
+
+无界会对子应用的 html、js、css 做模块级缓存以加速二次打开。若子应用资源已更新或需强制重新拉取，可调用 [clearAssetsCache](/api/clearAssetsCache.html) 按 host 清理缓存。

--- a/docs/guide/start.md
+++ b/docs/guide/start.md
@@ -10,7 +10,7 @@ collapsable: false
 ### 引入
 
 ```javascript
-import { bus, setupApp, preloadApp, startApp, destroyApp } from "wujie";
+import { bus, setupApp, preloadApp, startApp, destroyApp, refreshApp, clearAssetsCache } from "wujie";
 ```
 
 ::: tip 提示

--- a/docs/pack/index.md
+++ b/docs/pack/index.md
@@ -25,7 +25,7 @@ import WujieVue from "wujie-vue2";
 // vue3
 import WujieVue from "wujie-vue3";
 
-const { bus, setupApp, preloadApp, destroyApp } = WujieVue;
+const { bus, setupApp, preloadApp, destroyApp, refreshApp, clearAssetsCache } = WujieVue;
 
 Vue.use(WujieVue);
 ```
@@ -66,6 +66,23 @@ Vue.use(WujieVue);
 ### destroyApp
 
 [同 API](/api/destroyApp.html)
+
+### refreshApp
+
+[同 API](/api/refreshApp.html)
+
+### clearAssetsCache
+
+[同 API](/api/clearAssetsCache.html)
+
+### refresh
+
+组件实例方法，**无需传参**。销毁当前子应用实例后，自动复用组件当前 props（`name`、`url`、`alive` 等）全量重建。返回 `startAppQueue` 对应的 `Promise`，可在刷新完成后继续后续逻辑。
+
+```javascript
+// 直接调用，不需要传递任何参数
+await this.$refs.wujie.refresh();
+```
 
 ## 原理
 

--- a/docs/pack/react.md
+++ b/docs/pack/react.md
@@ -18,7 +18,7 @@ npm i wujie-react -S
 ```javascript
 import WujieReact from "wujie-react";
 
-const { bus, setupApp, preloadApp, destroyApp } = WujieReact;
+const { bus, setupApp, preloadApp, destroyApp, refreshApp, clearAssetsCache } = WujieReact;
 ```
 
 ## 使用
@@ -55,6 +55,23 @@ const { bus, setupApp, preloadApp, destroyApp } = WujieReact;
 ### destroyApp
 
 [同 API](/api/destroyApp.html)
+
+### refreshApp
+
+[同 API](/api/refreshApp.html)
+
+### clearAssetsCache
+
+[同 API](/api/clearAssetsCache.html)
+
+### refresh
+
+组件实例方法，**无需传参**。销毁当前子应用实例后，自动复用组件当前 props 全量重建。返回 `startAppQueue` 对应的 `Promise`。
+
+```javascript
+// 直接调用，不需要传递任何参数
+await this.wujieRef.current.refresh();
+```
 
 ## 原理
 


### PR DESCRIPTION
## Summary
- 新增 `refreshApp`、`clearAssetsCache` API 文档页
- 更新 VitePress 侧边栏，并在快速上手、运行模式、预加载指南中补充交叉引用
- 更新 Vue / React 组件封装文档，说明 `refreshApp` 静态方法与组件 `refresh()` 实例方法（无需传参）

## Test plan
- [ ] 本地运行 `cd docs && pnpm docs:dev` 确认侧边栏与页面链接正常
- [ ] 检查 `/api/refreshApp`、`/api/clearAssetsCache` 页面渲染
- [ ] 检查 `/pack/` 与 `/pack/react` 中 refresh 小节展示


Made with [Cursor](https://cursor.com)