### PR TITLE
fix(vue2): avoid reserved style prop warning

### DIFF
--- a/packages/wujie-vue2/index.js
+++ b/packages/wujie-vue2/index.js
@@ -39,7 +39,6 @@ const wujieVueOptions = {
     activated: { type: Function, default: null },
     deactivated: { type: Function, default: null },
     loadError: { type: Function, default: null },
-    style: { type: Object, default: undefined },
     iframeAddEventListeners: { type: Array, default: null },
     iframeOnEvents: { type: Array, default: null },
   },
@@ -140,11 +139,11 @@ const wujieVueOptions = {
     clearStartAppQueue(this.name, this.startAppQueue);
   },
   render(c) {
+    // Vue 2 会自动将组件 VNode 的 style 合并到根元素，避免声明同名保留 prop。
     return c("div", {
       style: {
         width: this.width,
         height: this.height,
-        ...this.style,
       },
       ref: "wujie",
     });


### PR DESCRIPTION
##### Checklist

- [x] 提交符合 commit 规范
- [x] 本地验证通过

##### 详细描述

- 问题：`wujie-vue2` 把 Vue 2 保留属性 `style` 声明成 prop，导致组件注册时就输出 `"style" is a reserved attribute and cannot be used as component prop.`；即使调用方没有传 `style` 也会出现。
- 根因：Vue 2 的模板和渲染函数会把组件 `style` 放在 VNode data 中，并自动合并到组件唯一根元素；当前 prop 声明和 `...this.style` 展开既与保留属性规则冲突，也不是常规 `style` 绑定生效的路径。
- 修复：移除 Vue 2 适配器中的 `style` prop 和冗余展开，继续由 Vue 2 原生样式合并处理外部 `style`，同时保留适配器自己的 `width` / `height`。
- 兼容性：父组件样式仍可覆盖适配器默认尺寸，未覆盖的内部尺寸继续保留，响应式样式更新行为不变；React 和 Vue 3 适配器未修改。

##### 验证

- Vue 2.6.14 隔离回归：修复前 1 条保留属性警告，修复后 0 条；父级 width 覆盖、内部 height、额外样式和动态更新均通过。
- Vue 2.7.16 隔离回归：0 条保留属性警告，同一组样式合并与动态更新断言通过。
- `pnpm --filter wujie-vue2 exec eslint index.js`
- `pnpm --filter wujie run lib`
- `pnpm --filter wujie-vue2 run esm`
- `pnpm --filter wujie-vue2 run lib`
- `npm pack --dry-run --ignore-scripts --json`

Closes #993
Closes #1011
Closes #1104
